### PR TITLE
Replace .svg by .* and add Makefile rule

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,6 +13,11 @@ PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+SOURCEDIR       = .
+IMAGEDIRS       = images
+# SVG to PDF conversion
+SVG2PDF       = inkscape
+SVG2PDF_FLAGS = 
 
 .PHONY: help
 help:
@@ -44,9 +49,19 @@ help:
 	@echo "  coverage   to run coverage check of the documentation (if enabled)"
 	@echo "  dummy      to check syntax errors of document sources"
 
+# 
+# Pattern rule for converting SVG to PDF
+%.pdf : %.svg
+	$(SVG2PDF) -f $< -A $@ 
+# Build a list of SVG files to convert to PDFs
+PDFs := $(foreach dir, $(IMAGEDIRS), $(patsubst %.svg,%.pdf,$(wildcard $(SOURCEDIR)/$(dir)/*.svg)))
+# Make a rule to build the PDFs
+images: $(PDFs)
+
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm $(PDFs)
 
 .PHONY: html
 html:
@@ -127,7 +142,7 @@ epub3:
 	@echo "Build finished. The epub3 file is in $(BUILDDIR)/epub3."
 
 .PHONY: latex
-latex:
+latex: $(PDFs)
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
@@ -135,7 +150,7 @@ latex:
 	      "(use \`make latexpdf' here to do that automatically)."
 
 .PHONY: latexpdf
-latexpdf:
+latexpdf: $(PDFs)
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -52,7 +52,7 @@ Establishing encryption happens as a side effect when people send each other mai
 "Happy path" example: 1:1 communication
 ---------------------------------------
 
-.. image:: images/autocrypthappy.svg
+.. image:: ./images/autocrypthappy.*
 
 Consider a blank state and a first outgoing message from Alice to Bob::
 


### PR DESCRIPTION
* replace .svg images by .* in order that `make latexpdf` not to fail.
* while [sphinx-doc #2859](https://github.com/sphinx-doc/sphinx/pull/2859) is merged, add rule in Makefile to generate pdfs from svgs.
* `make latexpdf` will still fail if inkscape is not installed. The alternative will be to do not include the rule "images" in "latexpdf" and include the pdfs in git.