### PR TITLE
WIP: generating keys with pgpy and importing them with gnupg works now

### DIFF
--- a/src/experiments/gpg_utils.py
+++ b/src/experiments/gpg_utils.py
@@ -38,8 +38,8 @@ def generate_rsa_key(uid='alice@testsuite.autocrypt.org',
     """
     # NOTE: default algorithm was decided to be RSA and size 2048.
     key = PGPKey.new(alg_key, size)
-    # NOTE: pgpy implements separate attributes for name and e-mail address
-    # is mandatory.
+    # NOTE: pgpy implements separate attributes for name and e-mail address.
+    # name is mandatory.
     # Here using e-mail address for the attribute name in order for
     # the uid to be the e-mail address.  If name attribute is set to
     # empty string and email to the e-mail address, the uid will be '
@@ -66,7 +66,7 @@ def generate_rsa_key(uid='alice@testsuite.autocrypt.org',
 
 
 def generate_ec_key():
-    # NOTE: pgpy does implement ed25519 nor cv25519
+    # NOTE: currently pgpy does not implement ed25519 nor cv25519
     pass
 
 
@@ -95,7 +95,7 @@ def import_key_into_keyring(key, gnupghome_path='/tmp/gnupg'):
     .. note::
         pgpy does not implement filesystem keyring
     """
-    # NOTE: pgpy does not implement filesystem keyring
+    # NOTE: currently pgpy does not implement filesystem keyring
     pass
 
 

--- a/src/experiments/gpg_utils.py
+++ b/src/experiments/gpg_utils.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 def generate_rsa_key(uid='alice@testsuite.autocrypt.org',
                      alg_key=PubKeyAlgorithm.RSAEncryptOrSign,
                      alg_subkey=PubKeyAlgorithm.RSAEncryptOrSign,
-                     size=2048):
+                     size=2048,
+                     add_subkey=True):
     # RSAEncrypt is deprecated, therefore using RSAEncryptOrSign
     # also for the subkey
     """Generate PGPKey object.
@@ -58,8 +59,9 @@ def generate_rsa_key(uid='alice@testsuite.autocrypt.org',
                              CompressionAlgorithm.BZ2,
                              CompressionAlgorithm.ZIP,
                              CompressionAlgorithm.Uncompressed])
-    subkey = PGPKey.new(alg_subkey, size)
-    key.add_subkey(subkey, usage={KeyFlags.EncryptCommunications,
+    if add_subkey is True:
+        subkey = PGPKey.new(alg_subkey, size)
+        key.add_subkey(subkey, usage={KeyFlags.EncryptCommunications,
                                   KeyFlags.EncryptStorage})
     logger.debug('Created key with fingerprint %s', key.fingerprint)
     return key

--- a/src/experiments/gpg_utils.py
+++ b/src/experiments/gpg_utils.py
@@ -130,6 +130,14 @@ def export_pubkey_to_file(key, pubkey_path='/tmp/pubkey.asc'):
     logger.debug('Exported public key with fingerprint %s to file %s', key.fingerprint, pubkey_path)
 
 
+def key_shortid(key):
+    return key.fingerprint.replace(' ', '')[:8]
+
+
+def key_longid(key):
+    return key.fingerprint.replace(' ', '')[:16]
+
+
 def key_fp(key):
     """Key fingerprint.
 

--- a/src/experiments/requirements.txt
+++ b/src/experiments/requirements.txt
@@ -1,1 +1,3 @@
-PGPy>=0.4.0
+# PGPy>=0.4.0
+# while PGPy generate new release, we can use this commit
+-e git+https://github.com/SecurityInnovation/PGPy.git@2514c3908d62ec6c82fcd99adf4738849667d540

--- a/src/experiments/send_autocrypt_mail.py
+++ b/src/experiments/send_autocrypt_mail.py
@@ -20,8 +20,8 @@ def main():
                         help='Set logging level to debug',
                         action='store_true')
     # TODO: add directories where import/export keys
-    # parser.add_argument('-o', '--outputdir', help='',
-    #                     default=OUTPUT_DIR)
+    parser.add_argument('-o', '--outputdir', help='',
+                         default=None)
     parser.add_argument('-v', '--version', action='version',
                         help='version',
                         version='%(prog)s ' + version)
@@ -38,6 +38,10 @@ def main():
                         default=True)
     parser.add_argument('-s', '--subkey',
                         help='Generate encryption subkey',
+                        default=True)
+    parser.add_argument('-m', '--mail',
+                        help='Generate key and send mail, '\
+                              'otherwise generate only key',
                         default=True)
     args = parser.parse_args()
 
@@ -62,23 +66,23 @@ def main():
 
     if args.gen is True:
         # generate a new key
-        if args.subkey is False:
-            key = gpg_utils.generate_rsa_key(args.sender, add_subkey=False)
-        else:
-            key = gpg_utils.generate_rsa_key(args.sender)
+        key = gpg_utils.generate_rsa_key(args.sender,
+                                         add_subkey=args.subkey)
         # export key to files
-        gpg_utils.export_key_to_file(key)
-        gpg_utils.export_pubkey_to_file(key)
+        gpg_utils.export_key_to_file(key, outputdir=args.outputdir)
+        gpg_utils.export_pubkey_to_file(key, outputdir=args.outputdir)
     else:
         # import key from a file
         key = gpg_utils.key_from_file()
-    keybase64 = gpg_utils.key_base64(key)
-    keyfp = gpg_utils.key_fp(key)
-    msg = generate_autocrypt.generate_email(keybase64,
-                                            keyfp,
-                                            args.sender,
-                                            args.recipient)
-    generate_autocrypt.send_email(msg, args.sender, args.recipient)
+    if args.mail is True:
+        keybase64 = gpg_utils.key_base64(key)
+        keyfp = gpg_utils.key_fp(key)
+        msg = generate_autocrypt.generate_email(keybase64,
+                                                keyfp,
+                                                args.sender,
+                                                args.recipient)
+        generate_autocrypt.send_email(msg, args.sender,
+                                      args.recipient)
 
 
 if __name__ == '__main__':

--- a/src/experiments/send_autocrypt_mail.py
+++ b/src/experiments/send_autocrypt_mail.py
@@ -39,6 +39,9 @@ def main():
     parser.add_argument('-s', '--subkey',
                         help='Generate encryption subkey',
                         default=True)
+    parser.add_argument('-p', '--protect',
+                        help='Protect private key',
+                        default=False)
     parser.add_argument('-m', '--mail',
                         help='Generate key and send mail, '\
                               'otherwise generate only key',

--- a/src/experiments/send_autocrypt_mail.py
+++ b/src/experiments/send_autocrypt_mail.py
@@ -36,6 +36,9 @@ def main():
     parser.add_argument('-g', '--gen',
                         help='Generate a OpenPGP key pair',
                         default=True)
+    parser.add_argument('-s', '--subkey',
+                        help='Generate encryption subkey',
+                        default=True)
     args = parser.parse_args()
 
     if args.debug:
@@ -59,14 +62,16 @@ def main():
 
     if args.gen is True:
         # generate a new key
-        key = gpg_utils.generate_rsa_key(args.sender)
+        if args.subkey is False:
+            key = gpg_utils.generate_rsa_key(args.sender, add_subkey=False)
+        else:
+            key = gpg_utils.generate_rsa_key(args.sender)
         # export key to files
         gpg_utils.export_key_to_file(key)
         gpg_utils.export_pubkey_to_file(key)
     else:
         # import key from a file
         key = gpg_utils.key_from_file()
-        pass
     keybase64 = gpg_utils.key_base64(key)
     keyfp = gpg_utils.key_fp(key)
     msg = generate_autocrypt.generate_email(keybase64,


### PR DESCRIPTION
Code for generating keys is now in experiments/gpg_utils.py.

With the PGPy new commits in develop, mentioned in https://github.com/autocrypt/autocrypt/issues/31#issuecomment-280498306, the test created by hpk42 in https://github.com/autocrypt/autocrypt/blob/hpk1/src/autocrypt/key.py now passes.