### PR TITLE
use addr as the email address attribute

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -64,7 +64,7 @@ Consider a blank state and a first outgoing message from Alice to Bob::
 Upon sending this mail, Alice's MUA will add a header which contains her
 encryption key::
 
-    Autocrypt: to=alice@a.example; type=p; prefer-encrypted=yes; key=...
+    Autocrypt: addr=alice@a.example; type=p; prefer-encrypted=yes; key=...
 
 Bob's MUA will scan the incoming mail, find Alice's key and store it
 associated to the ``alice@a.example`` address taken from the
@@ -73,7 +73,7 @@ find the key and signal to Bob that the mail will be encrypted and
 after finalization of the mail encrypt it.  Moreover, Bob's MUA will
 add its own encryption info::
 
-    Autocrypt: to=bob@b.example; type=p; prefer-encrypted=yes; key=...
+    Autocrypt: addr=bob@b.example; type=p; prefer-encrypted=yes; key=...
 
 When Alice's MUA now scans the incoming mail from Bob it will store
 Bob's key and the fact that Bob sent an encrypted mail.  Subsequently

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -92,14 +92,14 @@ headers as invalid and fall back to the one without a ``priority``
 attribute.
 
 
-Why do you use the ``to=`` attribute rather than the uid from the key?
+Why do you use the ``addr`` attribute rather than the uid from the key?
 ----------------------------------------------------------------------
 
 We need to store state about the key to use for a given e-mail
 address. Just importing the key into a keyring won't cut it.
 
 We want to be able to handle the header without having to parse the
-key first.  We believe that using the 'to' attribute will be more
+key first.  We believe that using the 'addr' attribute will be more
 forward compatible. For example we discussed hashing the uid in the
 keys so in case they leak to pgp keyservers they do not leak the e-mail
 address. This would not be compatible with requiring the e-mail address

--- a/doc/images/autocrypthappy.svg
+++ b/doc/images/autocrypthappy.svg
@@ -818,7 +818,7 @@
          sodipodi:role="line"
          x="112.75412"
          y="-221.617"
-         id="tspan38747">Autocrypt: to=alice@a.example; prefer-encrypted=yes; key=</tspan><tspan
+         id="tspan38747">Autocrypt: addr=alice@a.example; prefer-encrypted=yes; key=</tspan><tspan
          sodipodi:role="line"
          x="112.75412"
          y="-214.117"
@@ -855,7 +855,7 @@
          sodipodi:role="line"
          id="tspan38849"
          x="112.75412"
-         y="-71.150101">Autocrypt: to=alice@a.example; prefer-encrypted=yes; key=</tspan><tspan
+         y="-71.150101">Autocrypt: addr=alice@a.example; prefer-encrypted=yes; key=</tspan><tspan
          sodipodi:role="line"
          id="tspan38851"
          x="112.75412"
@@ -911,7 +911,7 @@
          sodipodi:role="line"
          id="tspan38966"
          x="112.75412"
-         y="-173.4501">Autocrypt: to=bob@b.example; prefer-encrypted=yes; key=</tspan><tspan
+         y="-173.4501">Autocrypt: addr=bob@b.example; prefer-encrypted=yes; key=</tspan><tspan
          sodipodi:role="line"
          id="tspan38968"
          x="112.75412"

--- a/doc/level0.rst
+++ b/doc/level0.rst
@@ -119,8 +119,8 @@ During message composition, if the :mailheader:`From:` header of the
 outgoing e-mail matches an address that the Autocrypt-capable agent
 knows the secret key material for, it SHOULD include an Autocrypt
 header. This header contains the associated public key material as
-``key=`` attribute, and the same sender address that is used in the
-``From`` header in the ``to=`` attribute to confirm the
+``key`` attribute, and the same sender address that is used in the
+``From`` header in the ``addr`` attribute to confirm the
 association. The most minimal Level 0 MUA will only include these two
 attributes.
 
@@ -139,9 +139,9 @@ Deriving a Parsed :mailheader:`Autocrypt` Header from a Message
 
 The :mailheader:`Autocrypt` header has the following format::
 
-    Autocrypt: to=a@b.example.org; [type=p;] [prefer-encrypt=mutual;] key=BASE64
+    Autocrypt: addr=a@b.example.org; [type=p;] [prefer-encrypt=mutual;] key=BASE64
 
-The ``to`` attribute indicates the single recipient address this
+The ``addr`` attribute indicates the single recipient address this
 header is valid for. In case this address differs from the one the MUA
 considers the sender of the e-mail in parsing, which will usually be
 the one specified in the :mailheader:`From` header, the entire header
@@ -194,7 +194,7 @@ OpenPGP packets:
  - a binding signature over ``Ke`` by ``Kp``
 
 The content of the user id packet is only decorative. By convention, it
-contains the same address used in the ``to`` attribute in angle brackets,
+contains the same address used in the ``addr`` attribute in angle brackets,
 conforming to the :rfc:`2822` grammar ``angle-addr``.
 
 These packets MUST be assembled in binary format (not ASCII-armored),


### PR DESCRIPTION
Also always refer to attributes without the trailing `=`.

addr is a bit more specific (grep is easier now).