### PR TITLE
only discourage sending encrypted after a timeout

### DIFF
--- a/doc/TODO.txt
+++ b/doc/TODO.txt
@@ -2,11 +2,7 @@
 
 open issues:
 
-- refine "discourage" user interface handling: in "flip-flop" situations don't
-  give scary warning messages when users explicitely choose to encrypt.
-  (PR, azul)
- 
-- include own prefer-encrypt setting in the autocrypt setup message 
+- include own prefer-encrypt setting in the autocrypt setup message
   so that the other client can start off from the "imported" prefer-encrypt
   setting (so e.g. a "mutual" setting carries over and will not lead to
   flip-flopping when sending mails to third parties which means that the
@@ -16,7 +12,7 @@ open issues:
 - fix own state MUST (PR, vincent)
 
 - move "pah" attributes (parsed autocrypt header) to "peerstate"
-  and "update internal state" section at least somewhat 
+  and "update internal state" section at least somewhat
   (remove TODOs, ...) (vincent, patrick, PR)
 
 Setup Message:
@@ -26,18 +22,18 @@ Setup Message:
 - User ID does not need to match an email (it's "decorative") (PR, holger)
 
 - alphanumeric versus number "setup codes" (discussion)
-  and also consider error-correction 
+  and also consider error-correction
 
 - refining/fixating the symmetric "setup code" encryption and Setup Message format
   (defending particularly against secret-key-injection because if we let the user
   go through the effort of transfering 128 bit of entropy out-of-band we should try
   hard to protect a MITM exchanging keys)  (discussion based on a PR?)
   two known solutions:
-  - mandate exact PGP message 
+  - mandate exact PGP message
   - put and verify Setup Code in the decrypted cleartext of the Setup Message
   - just say "the message MUST be decrypted using the Setup Code" and
     rely on people calling their engines/APIs correctly and note that particularly
     gpg might appear to have decrypted symmetricatally but did something else
 
- 
-  
+
+

--- a/doc/level0.rst
+++ b/doc/level0.rst
@@ -482,8 +482,8 @@ algorithm:
 4. If ``pah.prefer_encrypt`` is ``mutual``, and the user's own
    ``own_state.prefer_encrypt`` is ``mutual``, then the recommendation
    is ``encrypt``.
-5. If ``pah.prefer_encrypt`` is ``reset``, then the recommendation is
-   ``discourage``.
+5. If ``pah.prefer_encrypt`` is ``reset`` and the ``pah.last_seen`` is
+   more than one month ago, then the recommendation is ``discourage``.
 
 Otherwise, the recommendation is ``available``.
 


### PR DESCRIPTION
If an autocrypt mail was seen within the last month we allow encrypting
without a warning.

We are trying to destinguish two cases here:
 * the recipient is using an autocrypt and a naive client in parallel
 * the recipient stopped using autocrypt

In the former case we expect to see autocrypt headers from time to time.
We don't want to switch between different behaviours frequently.

In the latter case the recipient may still see unreadable for a
month but we will discourage sending encrypted mail afterwards.