### PR TITLE
use type=0 instead of type=p

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -64,7 +64,7 @@ Consider a blank state and a first outgoing message from Alice to Bob::
 Upon sending this mail, Alice's MUA will add a header which contains her
 encryption key::
 
-    Autocrypt: addr=alice@a.example; type=p; prefer-encrypted=yes; key=...
+    Autocrypt: addr=alice@a.example; type=0; prefer-encrypted=yes; key=...
 
 Bob's MUA will scan the incoming mail, find Alice's key and store it
 associated to the ``alice@a.example`` address taken from the
@@ -73,7 +73,7 @@ find the key and signal to Bob that the mail will be encrypted and
 after finalization of the mail encrypt it.  Moreover, Bob's MUA will
 add its own encryption info::
 
-    Autocrypt: addr=bob@b.example; type=p; prefer-encrypted=yes; key=...
+    Autocrypt: addr=bob@b.example; type=0; prefer-encrypted=yes; key=...
 
 When Alice's MUA now scans the incoming mail from Bob it will store
 Bob's key and the fact that Bob sent an encrypted mail.  Subsequently

--- a/doc/level0.rst
+++ b/doc/level0.rst
@@ -335,7 +335,7 @@ Deriving a Parsed :mailheader:`Autocrypt` Header from a Message
 
 The :mailheader:`Autocrypt` header has the following format::
 
-    Autocrypt: addr=a@b.example.org; [type=p;] [prefer-encrypt=mutual;] key=BASE64
+    Autocrypt: addr=a@b.example.org; [type=0;] [prefer-encrypt=mutual;] key=BASE64
 
 The ``addr`` attribute indicates the single recipient address this
 header is valid for. In case this address differs from the one the MUA
@@ -344,7 +344,7 @@ the one specified in the :mailheader:`From` header, the entire header
 MUST be treated as invalid.
 
 The ``type`` and ``key`` attributes specify the type and data of the
-key material.  For now the only supported type is ``p``, which
+key material.  For now the only supported type is ``0``, which
 represents a specific subset of OpenPGP (see the next section), and is
 also the default.  Headers with an unknown ``type`` MUST be treated as
 invalid.  The value of the ``key`` attribute is a Base64
@@ -375,7 +375,7 @@ and all :mailheader:`Autocrypt` headers discarded as invalid.
 
    - Document why we skip on more than one valid header?
 
-``type=p``: OpenPGP Based key data
+``type=0``: OpenPGP Based key data
 ++++++++++++++++++++++++++++++++++
 
 For maximum interoperability, a certificate sent by an
@@ -429,7 +429,7 @@ here.
 Conceptually, we represent this state as a table named
 ``autocrypt_peer_state`` indexed by the peer's :doc:`canonicalized
 e-mail address <address-canonicalization>` and key type.  In level 0,
-there is only one type, ``p``, so level 0 agents can implement this by
+there is only one type, ``0``, so level 0 agents can implement this by
 indexing only the peer's e-mail address.
 
 For each e-mail address and type, an agent MUST store the following
@@ -631,7 +631,7 @@ Encrypt outbound mail as requested
 
 As the user composes mail, in some circumstances, the MUA may be
 instructed by the user to encrypt the message.  If the recipient's
-keys are all of ``type=p``, and the sender has keys for all recipients
+keys are all of ``type=0``, and the sender has keys for all recipients
 (as well as themselves), they should construct the encrypted message
 as a :rfc:`PGP/MIME <3156>` encrypted+signed message, encrypted to all
 recipients and the public key whose secret is controlled by the MUA

--- a/doc/next-steps.rst
+++ b/doc/next-steps.rst
@@ -44,7 +44,7 @@ New Types
 .. todo::
 
    how to deal with multiple types (at least when a new type is
-   specified).  When we support types other than `p`, it's possible
+   specified).  When we support types other than `0`, it's possible
    that users will have multiple keys available, each with a different
    type.  That seems likely to introduce some awkward choices during
    message composition time, particularly for multi-recipient
@@ -90,7 +90,7 @@ Guidance on masking Key IDs
 
 If any recipients are in :mailheader:`Bcc:` (rather than
 :mailheader:`To:` or :mailheader:`Cc:`), and the key types used are
-all OpenPGP (``type=p``), then the agent SHOULD mask the recipient key
+all OpenPGP (``type=0``), then the agent SHOULD mask the recipient key
 ID in the generated PKESK packets that correspond to the Bcc'ed
 recipents.  It does not need to mask recipient key IDs of normal
 recipients.


### PR DESCRIPTION
type=p implies something about OpenPGP or something else.  We think
that we can better handle upgrades to new key formats (including
curve25519) by just having a strong opinion about key formats, and
restricting type=0 to OpenPGP rsa2048.

By using type=0 instead of type=p we remove the temptation to
editorialize about what other types might exist, or to try to
interpret the type header semantically instead of looking it up in a
table.

Please also see #82 for followup that will detail MUSTs and SHOULDs.