### PR TITLE
Clarify requirements language around type=0 keys

### DIFF
--- a/doc/level0.rst
+++ b/doc/level0.rst
@@ -309,12 +309,14 @@ Header injection in outbound mail
 
 During message composition, if the :mailheader:`From:` header of the
 outgoing e-mail matches an address that the Autocrypt-capable agent
-knows the secret key material for, it SHOULD include an Autocrypt
-header. This header contains the associated public key material as
-``key`` attribute, and the same sender address that is used in the
-``From`` header in the ``addr`` attribute to confirm the
-association. The most minimal Level 0 MUA will only include these two
-attributes.
+knows the secret key material (``own_state.secret_key``) for, it
+SHOULD include an Autocrypt header. This header MUST contain the
+associated public key material (``own_state.key``) as ``key``
+attribute, and the same sender address that is used in the ``From``
+header in the ``addr`` attribute to confirm the association.  The most
+minimal Level 0 MUA will only include these two attributes.  If
+``own_state.prefer_encrypt`` is set to ``mutual`` then the header MUST
+have a ``prefer-encrypt`` attribute set to ``mutual``.
 
 If the :mailheader:`From:` address changes during message composition
 (E.g. if the user selects a different outbound identity), the
@@ -397,12 +399,8 @@ and then base64-encoded.
 
 A Level 0 MUA MUST be capable of processing and handling 2048-bit RSA
 public keys.  It MAY support other strong OpenPGP key formats found in
-a ``type=0`` Autocrypt header.  For example, some clients might choose
-to accept Curve 25519 public keys (ed25519 for ``Kp`` and cv25519 for
-``Ke``), but some underlying toolkits may not yet support these
-algorithms, so it is not advised to send these keys in a ``type=0``
-header if the user desires to maximize the number of peers who can
-send them encrypted messages.
+a ``type=0`` Autocrypt header (for example, by passing it agnostically
+to an OpenPGP backend for handling).
 
 
 Internal state storage
@@ -674,8 +672,8 @@ Level 0 MUAs maintain an internal structure ``own_state`` for each
 account on which Autocrypt is enabled. ``own_state`` has the following
 members:
 
- * ``secret_key`` -- the secret key used for this account (see "Secret
-   Key Generation and storage" above).
+ * ``secret_key`` -- the RSA 2048-bit secret keys used for this
+   account (see "Secret Key Generation and storage" above).
  * ``key`` -- the OpenPGP transferable public key derived from
    ``secret_key``.
  * ``prefer_encrypt`` -- the user's own

--- a/doc/level0.rst
+++ b/doc/level0.rst
@@ -398,7 +398,7 @@ These packets MUST be assembled in binary format (not ASCII-armored),
 and then base64-encoded.
 
 A Level 0 MUA MUST be capable of processing and handling 2048-bit RSA
-public keys.  It MAY support other strong OpenPGP key formats found in
+public keys.  It MAY support other OpenPGP key formats found in
 a ``type=0`` Autocrypt header (for example, by passing it agnostically
 to an OpenPGP backend for handling).
 

--- a/doc/level0.rst
+++ b/doc/level0.rst
@@ -672,7 +672,7 @@ Level 0 MUAs maintain an internal structure ``own_state`` for each
 account on which Autocrypt is enabled. ``own_state`` has the following
 members:
 
- * ``secret_key`` -- the RSA 2048-bit secret keys used for this
+ * ``secret_key`` -- the RSA 2048-bit secret key used for this
    account (see "Secret Key Generation and storage" above).
  * ``key`` -- the OpenPGP transferable public key derived from
    ``secret_key``.

--- a/doc/level0.rst
+++ b/doc/level0.rst
@@ -396,9 +396,13 @@ These packets MUST be assembled in binary format (not ASCII-armored),
 and then base64-encoded.
 
 A Level 0 MUA MUST be capable of processing and handling 2048-bit RSA
-keys.  It SHOULD be capable of handling Curve 25519 keys (ed25519 for
-``Kp`` and cv25519 for ``Ke``), but some underlying toolkits may not
-yet support Curve 25519.  It MAY support other OpenPGP key formats.
+public keys.  It MAY support other strong OpenPGP key formats found in
+a ``type=0`` Autocrypt header.  For example, some clients might choose
+to accept Curve 25519 public keys (ed25519 for ``Kp`` and cv25519 for
+``Ke``), but some underlying toolkits may not yet support these
+algorithms, so it is not advised to send these keys in a ``type=0``
+header if the user desires to maximize the number of peers who can
+send them encrypted messages.
 
 
 Internal state storage


### PR DESCRIPTION
Closes #82

When generating keys:
  * we want to say "MUST" generate rsa2048 for v0.

When looking at public keys from a peer:
  * we want to say "MUST" accept rsa2048 and "MAY" accept
    other OpenPGP keys.

this was pretty much already present, i just weakened the SHOULD a
little bit on curve25519.