### PR TITLE
user id MUST NOT be empty string (gnupg bug)

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -407,7 +407,8 @@ OpenPGP packets:
 
 The content of the user id packet is only decorative. By convention, it
 contains the same address used in the ``addr`` attribute in angle brackets,
-conforming to the :rfc:`2822` grammar ``angle-addr``.
+conforming to the :rfc:`2822` grammar ``angle-addr``. It MUST NOT be an empty
+string as this triggers a `bug in gnupg <https://dev.gnupg.org/T3203>`_.
 
 These packets MUST be assembled in binary format (not ASCII-armored),
 and then base64-encoded.


### PR DESCRIPTION
It is a bit strange to consider an implementation bug in the
spec like this - but i think we want to prevent triggering
the bug and so people MUST NOT use empty strings.

I think this is all that is missing to fix #26 .