### PR TITLE
user id SHOULD NOT be empty string

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -407,8 +407,8 @@ OpenPGP packets:
 
 The content of the user id packet is only decorative. By convention, it
 contains the same address used in the ``addr`` attribute in angle brackets,
-conforming to the :rfc:`2822` grammar ``angle-addr``. It MUST NOT be an empty
-string as this triggers a `bug in gnupg <https://dev.gnupg.org/T3203>`_.
+conforming to the :rfc:`2822` grammar ``angle-addr``. For compatibility
+concerns the user id SHOULD NOT be an empty string.
 
 These packets MUST be assembled in binary format (not ASCII-armored),
 and then base64-encoded.


### PR DESCRIPTION
No need to point out a specific bug in the spec. Even if this
particular bug is resolved the concerns probably remain.

If people don't follow the SHOULD they are responsible. Since
it does not break the spec it's not a MUST.