### PR TITLE
cleanup: remove encrypt button todo

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -777,7 +777,3 @@ If the Autocrypt recommendation is either ``available`` or
 ``encrypt``, the MUA SHOULD expose this UI during message composition
 to allow the user to make a different decision.
 
-.. todo::
-
-   - Should we really recommend hiding the encrypt UI? This reduces UI
-     consistency!


### PR DESCRIPTION
We already say that the client MAY hide the button.
This is not a SHOULD - maybe it was in the past.
Either way i think we are pretty clear that it's up
to the client to decide wether to display the button
when disabled. We only say it SHOULD display the button
if 'available' or 'encrypt'.

fixes #105

in line with what @r10s comment.