### PR TITLE
(WIP) rework "internal state storage" section to be smaller/more precise

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -49,7 +49,7 @@ and contributors, MUA developers and privacy enthusiasts.
    features
    contact
    examples
-   level0
+   level1
    dev-status
    address-canonicalization
    ecosystem-dangers


### PR DESCRIPTION
- THIS IS WORK IN PROGRESS, currently contains a bug in the "update peer state" section which needs to be fixed before proper review and certainly before merge. 

- collapse and better specify the algorithms for updating the
  peer_map's entries when incoming mails arrive (i tried to not
  change the logic, just rephrase/simplify it)

- remove indexing by key types for now as we only have one valid key type
  in Level1 anyway and the current spec did not provide proper semantics how
  to handle multiple key types -- i.e. how to get from an e-mail address
  to the proper key in the face of multiple types of keys. 

- rename a peer's ``state`` attribute to ``key_status`` which at
  least can be easily found in the text and avoids the more
  generic ``state`` term.

- simplify recommendation for multiple addresses: we can rely
  on the single recommendations to already take "reply-to-encrypted"
  into account. 

- fix a little ReST error