### PR TITLE
change motto to "encrypted e-mail for humans"

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
-Introducing Autocrypt: E-Mail Encryption for Everyone
-=====================================================
+Introducing Autocrypt: E-Mail Encryption for Humans
+===================================================
 
 **If users ask how they can secure their e-mail the answer
 should be as simple as: use an Autocrypt-enabled mail app!**

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
-Introducing Autocrypt: E-Mail Encryption for Humans
-===================================================
+Introducing Autocrypt: Encrypted E-Mail for Humans
+==================================================
 
 **If users ask how they can secure their e-mail the answer
 should be as simple as: use an Autocrypt-enabled mail app!**


### PR DESCRIPTION
as it has a nicer ring to it and also piggypacks on a "for humans"
meme widely used in the python community to signal convenient APIs,
see e.g. https://pypi.python.org/pypi?%3Aaction=search&term=for+humans+&submit=search
This relates to the aim of Autocrypt to provide "convenient" and
"usable" e-mail encryption.