### PR TITLE
add paragraph about multipart/report

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -296,6 +296,11 @@ overall. Additionally update the state as follows:
 - set ``state`` to ``mutual`` if the Autocrypt header contained a
   ``prefer-encrypt=mutual`` attribute, or ``nopreference`` otherwise
 
+A message with a content-type of ``multipart/report`` can be assumed
+to be auto-generated, and SHOULD be ignored if it does not contain an
+``Autocrypt`` header. This in particular avoids triggering a ``reset``
+state from received Message Disposition Notifications (:rfc:`3798`).
+
 .. _spam-filters:
 
 .. todo::


### PR DESCRIPTION
see #126

I wanted to avoid making the regular parsing more complicated for a fairly optional SHOULD, so I put it into an extra paragraph. It's not perfectly positioned, but I couldn't find a better place either.