### PR TITLE
fix discouraged for discourage

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -442,7 +442,7 @@ An outgoing e-mail will be sent encrypted in either of two cases:
 
 - the Autocrypt recommendation for the list of recipients is
   ``encrypt``, and not explicitly overridden by the user
-- the Autocrypt recommendation is ``available`` or ``discouraged``,
+- the Autocrypt recommendation is ``available`` or ``discourage``,
   and the user chose to encrypt.
 
 In this case, the MUA MUST construct the encrypted message as a
@@ -805,4 +805,3 @@ composition at all.
 If the Autocrypt recommendation is either ``available`` or
 ``encrypt``, the MUA SHOULD expose this UI during message composition
 to allow the user to make a different decision.
-


### PR DESCRIPTION
The proper recommendation is `discourage` not `discouraged`