### PR TITLE
remove these brackets because they are required fields

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -120,7 +120,7 @@ The ``Autocrypt`` Header
 
 The ``Autocrypt`` header has the following format::
 
-    Autocrypt: addr=a@b.example.org; [type=1;] [prefer-encrypt=mutual;] keydata=BASE64
+    Autocrypt: addr=a@b.example.org; type=1; prefer-encrypt=mutual; keydata=BASE64
 
 The ``addr`` attribute indicates the single recipient address this
 header is valid for. In case this address differs from the one the MUA
@@ -805,4 +805,3 @@ composition at all.
 If the Autocrypt recommendation is either ``available`` or
 ``encrypt``, the MUA SHOULD expose this UI during message composition
 to allow the user to make a different decision.
-


### PR DESCRIPTION
The brackets make it seem like `prefer-encrypt` and `type` are optional -- are they? The documentation makes the impression that they are critical and required.