### PR TITLE
fix #140 clarify that keydata should be the same irrespective of reci…

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -110,11 +110,11 @@ If the ``From`` address changes during message composition (E.g. if
 the user selects a different outbound identity), the Autocrypt-capable
 client MUST change the ``Autocrypt`` header appropriately.
 
-A MUA MUST send out the same ``keydata`` value in messages, irrespective
-of message recipients.  If a new secret key is generated (e.g. for
-key-rotation schemes) then all subsequent outbound Autocrypt headers
-MUST use the new associated public key material as value for the
-``keydata`` attribute.
+An MUA SHOULD send out the same ``keydata`` value in all messages from
+a given outbound identity, irrespective of message recipients.  If a
+new OpenPGP certificate is generated (e.g., key-rotation or OpenPGP
+metadata update) then all subsequent outbound Autocrypt headers SHOULD
+use the new certificate for the ``keydata`` attribute.
 
 See :ref:`mua-happypath` for examples of outbound headers and
 the following sections for header format definitions and parsing.

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -110,6 +110,12 @@ If the ``From`` address changes during message composition (E.g. if
 the user selects a different outbound identity), the Autocrypt-capable
 client MUST change the ``Autocrypt`` header appropriately.
 
+A MUA MUST send out the same ``keydata`` value in messages, irrespective
+of message recipients.  If a new secret key is generated (e.g. for
+key-rotation schemes) then all subsequent outbound Autocrypt headers
+MUST use the new associated public key material as value for the
+``keydata`` attribute.
+
 See :ref:`mua-happypath` for examples of outbound headers and
 the following sections for header format definitions and parsing.
 


### PR DESCRIPTION
…pients

(you can key-rotate your own key but you cannot use per-recipient autocrypt keys)

fixes #140 