### PR TITLE
break up recommendation algorithm and explain more.

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -203,3 +203,19 @@ Use of a memory-hard KDF like scrypt or argon2 would be desirable in the future.
 However, at the point of this writing this is not specified in OpenPGP. It is a
 bigger concern to preserve compatibility and avoid friction with presently
 deployed OpenPGP software.
+
+Where does the "35 days" limit come from?
+-----------------------------------------
+
+The recommendation algorithm uses a duration gap of 35 days to make a
+decision in a few places.  This is an arbitrary value, which seemed
+plausible to most people who worked on the specification, based on the
+idea that for people who you want to communicate with regularly, it's
+not uncommon that the user has exchanged e-mails at least once a
+month.  It's intended to be slightly more than monthly, so that people
+who have scheduled e-mail exchanges (e.g. "please check in on the 1st
+of the month") will stay current.
+
+Future revisions to the recommendation algorithm may change this
+cutoff.  If you have evidence that there are algorithms that provide
+better results, :ref:`please share them <contact channels>`!

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -446,14 +446,14 @@ Preliminary Recommendation
 __________________________
 
 If either ``public_key`` is ``null``, or ``autocrypt_timestamp`` is
-more than a month older than ``gossip_key_timestamp``, set
+more than 35 days older than ``gossip_key_timestamp``, set
 ``target-keys[to-addr]`` to ``gossip_key`` and set
 ``preliminary-recommendation`` to ``discourage`` and skip to the
 :ref:`final-recommendation-phase`.
 
 Otherwise, set ``target-keys[to-addr]`` to ``public_key``.
 
-If ``autocrypt_timestamp`` is more than a month older than
+If ``autocrypt_timestamp`` is more than 35 days older than
 ``last_seen``, set ``preliminary-recommendation`` to ``discourage``.
 
 Otherwise, set ``preliminary-recommendation`` to ``available``.

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -402,7 +402,8 @@ The output of the Autocrypt recommendation algorithm has two elements:
 ``ui-recommendation`` can take four possible values:
 
  * ``disable``: Disable or hide any UI that would allow the user to
-   choose to encrypt the message.
+   choose to encrypt the message.  This happens iff encryption is not
+   immediately possible.
 
  * ``discourage``: Enable UI that would allow the user to choose to
    encrypt the message, but do not default to encryption. If the user
@@ -491,8 +492,7 @@ follows:
 
 1. If any recipient has a ``ui-recommendation`` of ``disable``, then
    the message's ``ui-recommendation`` is ``disable``.
-2. If the message being composed is a reply to an encrypted message,
-   or if every recipient has a ``ui-recommendation`` of ``encrypt``,
+2. If every recipient has a ``ui-recommendation`` of ``encrypt``,
    then the message ``ui-recommendation`` is ``encrypt``.
 3. If any recipient has a ``ui-recommendation`` of ``discourage``,
    then the message ``ui-recommendation`` is ``discourage``.

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -106,16 +106,17 @@ For the peer with the address ``addr``, an MUA MUST associate the
 following attributes with ``peers[addr]``:
 
 * ``last_seen``: The UTC timestamp of the most recent effective date
-  (:ref:`definition <effective_date>`) of all messages that the MUA has
-  processed from this peer.
+  (:ref:`definition <effective_date>`) of all messages that the MUA
+  has processed from this peer.
 * ``autocrypt_timestamp``: The UTC timestamp of the most recent
-  effective date of all messages containing a valid ``Autocrypt`` header
-  that the MUA has processed from this peer.
+  effective date (the "youngest") of all messages containing a valid
+  ``Autocrypt`` header that the MUA has processed from this peer.
 * ``public_key``: The value of the ``keydata`` attribute derived from
-  the most recent ``Autocrypt`` header received from the peer.
+  the youngest ``Autocrypt`` header that has ever been seen from the
+  peer.
 * ``prefer_encrypt``: The ``prefer-encrypt`` value (either
-  ``nopreference`` or ``mutual``) derived from most recent ``Autocrypt``
-  header received from the peer.
+  ``nopreference`` or ``mutual``) derived from the youngest
+  ``Autocrypt`` header ever seen from the peer.
 
 Autocrypt-capable MUAs that implement :ref:`Gossip <gossip>` should
 also associate the following additional attributes with

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -397,7 +397,7 @@ The output of the Autocrypt recommendation algorithm has two elements:
 
  * ``ui-recommendation``: a single state recommending the state of the
    encryption user interface, described below.
- * ``public_keys``: a set of keys to encrypt to (which may be empty).
+ * ``target-keys``: a map of recipient addresses to public keys.
 
 ``ui-recommendation`` can take four possible values:
 
@@ -424,8 +424,6 @@ The Autocrypt recommendation for a message composed to a single
 recipient with the e-mail address ``to-addr`` depends primarily on the
 value stored in :ref:`peers[to-addr] <peers>`.
 
-``public_keys`` starts as the empty set.
-
 Determine if encryption is possible
 ___________________________________
 
@@ -447,12 +445,12 @@ Preliminary Recommendation
 __________________________
 
 If either ``public_key`` is ``null``, or ``autocrypt_timestamp`` is
-more than a month older than ``gossip_key_timestamp``, put
-``gossip_key`` into ``public_keys`` and set
+more than a month older than ``gossip_key_timestamp``, set
+``target-keys[to-addr]`` to ``gossip_key`` and set
 ``preliminary-recommendation`` to ``discourage`` and skip to the
 :ref:`final-recommendation-phase`.
 
-Otherwise, put ``public_key`` into ``public_keys``.
+Otherwise, set ``target-keys[to-addr]`` to ``public_key``.
 
 If ``autocrypt_timestamp`` is more than a month older than
 ``last_seen``, set ``preliminary-recommendation`` to ``discourage``.
@@ -482,9 +480,14 @@ Recommendations for messages to multiple addresses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For level 1 MUAs, the Autocrypt recommendation for a message composed
-to multiple recipients, we derive the message's ``ui-recommendation``
-for the message from the recommendations for each recipient
-individually.
+to multiple recipients, we derive the message's recommendation from
+the recommendations for each recipient individually.
+
+The aggregate ``target-keys`` for the message is the merge of all
+recipient ``target-keys``.
+
+The aggregate ``ui-recommendation`` for the message is derived as
+follows:
 
 1. If any recipient has a ``ui-recommendation`` of ``disable``, then
    the message's ``ui-recommendation`` is ``disable``.
@@ -495,12 +498,6 @@ individually.
    then the message ``ui-recommendation`` is ``discourage``.
 
 Otherwise, the message ``ui-recommendation`` is ``available``.
-
-If the message ``ui-recommendation`` is ``disable``, then set
-``public_keys`` to the empty set.
-
-Otherise, set ``public_keys`` to the union of the individual
-recipients' ``public_keys`` recommendations.
 
 While composing a message, a situation might occur where the
 ``ui-recommendation`` is ``available``, the user has explicitly

--- a/doc/optional-state.rst
+++ b/doc/optional-state.rst
@@ -53,7 +53,7 @@ causes a *reset*:
      user-agent of the message
 
  - OPTIONAL in the case of a **reset** AND ``counting_since`` is more
-   than 30 days older than ``message_date``:
+   than 35 days older than ``message_date``:
 
    - set ``autocrypt_peer_state[A].counting_since`` to ``last_seen``
    - set ``autocrypt_peer_state[A].count_have_ach`` to zero

--- a/doc/optional-state.rst
+++ b/doc/optional-state.rst
@@ -53,7 +53,7 @@ causes a *reset*:
      user-agent of the message
 
  - OPTIONAL in the case of a **reset** AND ``counting_since`` is more
-   than a month older than ``message_date``:
+   than 30 days older than ``message_date``:
 
    - set ``autocrypt_peer_state[A].counting_since`` to ``last_seen``
    - set ``autocrypt_peer_state[A].count_have_ach`` to zero


### PR DESCRIPTION
 * clarify that the recommendation algorithm returns both a
   recommendation for the behavior of the encryption UI, and a list of
   keys.

 * move the "disabled" logic above the preliminary recommendation

 * add section headers to the phases of the algorithm

 * remove the ``public_key`` and ``gossip_key`` intermediate
   variables, which seem to add more confusion than they remove, since
   they shadow existing variables with the same name.

 * make preliminary recommendation an explicit intermediate variable.