### PR TITLE
clean up language in UI examples

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -1046,8 +1046,8 @@ The Setup Code shown in this example can be used with
 
 .. code-block:: none
 
-    You'll need to use this Setup Code in your other e-mail program to
-    use the Autocrypt Setup Message:
+    You'll need to use this Setup Code in your other e-mail app to use
+    the Autocrypt Setup Message:
 
         1742-0185-6197-
         1303-7016-8412-
@@ -1062,13 +1062,13 @@ can display a message like the example below:
 
 .. code-block:: none
 
-    We detected a message created by one of your other email
-    applications that contains the setup information for
-    Autocrypt. By importing these settings, you can apply
-    the same settings in (your application).
+    ExampleMail has detected an Autocrypt Setup Message created by one
+    of the other apps you use to access "alice@autocrypt.example".  By
+    importing the settings from this message, you can start using
+    Autocrypt here in ExampleMail too!
 
-    Please enter the Setup Code displayed by your other email
-    application to proceed:
+    Please enter the Setup Code displayed by your other e-mail app to
+    proceed:
 
                      17__ - ____ - ____ -
                      ____ - ____ - ____ -


### PR DESCRIPTION
For user-facing examples, use the term "e-mail app".  Also, make the
examples concrete, rather than leaving explicit placeholders.