### PR TITLE
rewrite the very intro to explain higher level focus of autocrypt and…

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -6,51 +6,43 @@
 Autocrypt Level 1: Enabling encryption, avoiding annoyances
 ===========================================================
 
-This specification is the result of maybe 2000 hours of talking, testing and
-coding iterations during 2017. Around 20 developers and many more users and
-trainers participated overall in Autocrypt sessions. The majority of these
-participants have engaged with the e-mail encryption space for a
-long time. There was overwhelming agreement that fresh approaches are needed
-and particularly ones that address usability concerns.
+Autocrypt aims to incrementally and carefully replace cleartext e-mail
+with end-to-end encrypted e-mail. This differs from the traditional focus
+on maximizing the security of an individual mail communication.
+**Sometimes Autocrypt recommends to send cleartext mail even though
+encryption would seem technically possible.** This is because we want to
+avoid unreadable mail for users. Users may mix both Autocrypt-capable
+and traditional mail apps and they may loose devices or otherwise loose
+the ability to decrypt in unrecoverable ways.  Reverting to cleartext
+when we suspect such situations is a key part of our aim to stay out of
+the way of users.
 
-Autocrypt aims to incrementally replace cleartext e-mail with end-to-end
-encrypted e-mail. It aims to sustainably grow the overall percentage of
-end-to-end encrypted messages relayed via the e-mail provider network.
-This differs from the traditional focus on maximizing the security of an
-individual mail communication. **Sometimes Autocrypt recommends to
-send cleartext mail even though encryption would be technically
-possible.** This is because of well-known annoyances around "i can't
-read your encrypted mail" situations. Autocrypt operates opportunistically
-and tries to stay out of the way of users who want to, first of all,
-communicate.
+Another major difference in approach is that Autocrypt Level 1 only
+defends against passive data collection attacks. We share and support
+:rfc:`the new perspective stated in RFC7435 ("Opportunistic Security: Some
+Protection Most of the Time") <7435#section-1.2>`. Protection against
+active adversaries (those which modify messages in transit) is the aim
+of future specifications.
 
-Another difference to traditional approaches is that Autocrypt Level 1
-only defends against passive data collection. Protection against active
-adversaries (those which modify messages in transit) is the aim of
-future specifications. We share and support :rfc:`the new perspective
-stated in RFC7435 ("Opportunistic Security: Some Protection Most of the
-Time") <7435#section-1.2>`.
+**Level 1 makes it easy for users to encrypt, based on an automatic and
+decentralized key distribution mechanism. There are no dependencies on
+key servers and it is meant to work with existing e-mail providers.**
+Level 1 focuses on the use of Autocrypt on a single device. Users get
+rudimentary support on using Autocrypt on more than one device or mail app.
+This is internally realized through sending and receiving an Autocrypt
+Setup Message, secured by manually entering a long number. Improving
+usability for maintaining synchronized Autocrypt state on multiple
+devices is the aim of future specification efforts.
 
-The Level 1 specification makes it easy for users to encrypt. There are
-no changes required from e-mail providers and there are no dependencies
-on key servers. The spec describes the basic capabilities required for a
-mail app to be Autocrypt-capable at Level 1, allowing it to exchange
-end-to-end encrypted e-mails with other Autocrypt-capable mail apps. For
-those familiar with existing e-mail specs, we use the term "mail app"
-and "MUA" interchangeably throughout the doc.
-
-For ease of implementation and deployment, Level 1 focuses on the use of
-Autocrypt on a single device. However, users get support for transfering
-Autocrypt secret keys to other devices. They need to enter a
-long number for securing the transfer which is technically realized
-through sending and receiving an e-mail message. We aim to improve
-usability around keeping synchronized Autocrypt state on multiple
-devices in subsequent Autocrypt specifications.
-
-We designed Level 1 to be relatively easy for developers to adopt. There is
-detailed guidance on protocol, internal state and user interface concerns.
-We have a good track record of supporting new implementers. Please
-don't hesitate to ask back or send comments.
+**Last but not least, Level 1 is meant to be relatively easy for
+developers to adopt.** It describes the basic capabilities required for
+a mail app to be Autocrypt-capable at Level 1, allowing it to exchange
+end-to-end encrypted e-mails with other Autocrypt-capable mail apps. The
+spec contains detailed guidance on protocol, internal state and user
+interface concerns. We have a good track record of supporting new
+implementers. Please don't hesitate to ask back or bring up issues or
+pull requests. Autocrypt is a living specification and we envision both
+bugfix and backward-compatible feature releases.
 
 .. only:: builder_html
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -31,13 +31,15 @@ future specifications. We share and support :rfc:`the new perspective
 stated in RFC7435 ("Opportunistic Security: Some Protection Most of the
 Time") <7435#section-1.2>`.
 
-For ease of implementation and deployment, Level 1 focuses on the use
-of Autocrypt on a single device. It also defines an initial mechanism for
-sharing secret keys between mail apps of a single user. We aim to improve the
-usability of secret key sharing in subsequent Autocrypt specifications.
+For ease of implementation and deployment, Level 1 focuses on the use of
+Autocrypt on a single device. Users get basic support for transfering
+secret keys between Autocrypt-capable mail apps.  They need to enter a
+long number for securing the transfer, technically realized through
+sending and receiving an e-mail message. We aim to improve the usability
+around secret key sharing in subsequent Autocrypt specifications.
 
 We designed Level 1 to be relatively easy for developers to adopt. There is
-detailed guidance on the protocol, internal state and usability issues.
+detailed guidance on protocol, internal state and usability issues.
 We have a good track record of supporting new implementers. Please
 don't hesitate to ask back and send comments.
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -8,16 +8,15 @@ Autocrypt Level 1: Enabling encryption, avoiding annoyances
 
 Autocrypt aims to incrementally replace cleartext e-mail with end-to-end
 encrypted e-mail. The Level 1 specification makes it easy for users to
-encrypt by adding neccessary cryptographic information to e-mail messages.
-There are no changes required from e-mail providers and there are no
-dependencies on key servers. The spec describes the basic capabilities
-required for a mail app to be Autocrypt-capable at Level 1, allowing it
-to exchange end-to-end encrypted e-mails with other Autocrypt-capable
-mail apps.
+encrypt.  There are no changes required from e-mail providers and there
+are no dependencies on key servers. The spec describes the basic
+capabilities required for a mail app to be Autocrypt-capable at Level 1,
+allowing it to exchange end-to-end encrypted e-mails with other
+Autocrypt-capable mail apps.
 
 This specification is the result of maybe 2000 hours of talking and
 coding iterations during 2017. Around 20 people and many more users and
-trainers participated in Autocrypt sessions.  The majority of these
+trainers participated in Autocrypt sessions. The majority of these
 participants have engaged with the e-mail encryption space for a
 long time. There was overwhelming agreement that fresh approaches focusing
 on usability concerns are needed.
@@ -25,8 +24,8 @@ on usability concerns are needed.
 Autocrypt aims to sustainably grow the overall percentage of end-to-end
 encrypted messages relayed via the e-email provider network. This
 differs from the focus on maximizing the security of an individual mail
-communication.  Another major difference in approach is that Autocrypt Level 1
-only defends against passive data collection.  Protection against active
+communication. Another major difference in approach is that Autocrypt Level 1
+only defends against passive data collection. Protection against active
 adversaries (those which modify messages in transit) is the aim of
 future specifications. We share and support :rfc:`the new perspective
 stated in RFC7435 ("Opportunistic Security: Some Protection Most of the
@@ -39,7 +38,7 @@ usability of secret key sharing in subsequent Autocrypt specifications.
 
 We designed Level 1 to be relatively easy for developers to adopt. There is
 detailed guidance on the protocol, internal state and usability issues.
-We have a good track record of supporting new implementers.  Please
+We have a good track record of supporting new implementers. Please
 don't hesitate to ask back and send comments.
 
 .. only:: builder_html

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -40,9 +40,10 @@ a mail app to be Autocrypt-capable at Level 1, allowing it to exchange
 end-to-end encrypted e-mails with other Autocrypt-capable mail apps. The
 spec contains detailed guidance on protocol, internal state and user
 interface concerns. We have a good track record of supporting new
-implementers. Please don't hesitate to ask back or bring up issues or
-pull requests. Autocrypt is a living specification and we envision both
-bugfix and backward-compatible feature releases.
+implementers. Please don't hesitate to `contact the group
+<https://autocrypt.org/en/latest/contact.html>`_ or bring up issues or
+pull requests. Autocrypt is a living specification and we envision
+both bugfix and backward-compatible feature releases.
 
 .. only:: builder_html
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -39,7 +39,7 @@ sending and receiving an e-mail message. We aim to improve the usability
 around secret key sharing in subsequent Autocrypt specifications.
 
 We designed Level 1 to be relatively easy for developers to adopt. There is
-detailed guidance on protocol, internal state and usability issues.
+detailed guidance on protocol, internal states and user interface concerns.
 We have a good track record of supporting new implementers. Please
 don't hesitate to ask back and send comments.
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -6,42 +6,53 @@
 Autocrypt Level 1: Enabling encryption, avoiding annoyances
 ===========================================================
 
-Autocrypt aims to incrementally replace cleartext e-mail with end-to-end
-encrypted e-mail. The Level 1 specification makes it easy for users to
-encrypt. There are no changes required from e-mail providers and there
-are no dependencies on key servers. The spec describes the basic
-capabilities required for a mail app to be Autocrypt-capable at Level 1,
-allowing it to exchange end-to-end encrypted e-mails with other
-Autocrypt-capable mail apps.
+Introduction and general design decisions
+-----------------------------------------
 
-This specification is the result of maybe 2000 hours of talking and
-coding iterations during 2017. Around 20 people and many more users and
-trainers participated in Autocrypt sessions. The majority of these
+This specification is the result of maybe 2000 hours of talking, testing and
+coding iterations during 2017. Around 20 developers and many more users and
+trainers participated overall in Autocrypt sessions. The majority of these
 participants have engaged with the e-mail encryption space for a
-long time. There was overwhelming agreement that fresh approaches focusing
-on usability concerns are needed.
+long time. There was overwhelming agreement that fresh approaches are needed
+and particularly ones that address usability concerns.
 
-Autocrypt aims to sustainably grow the overall percentage of end-to-end
-encrypted messages relayed via the e-email provider network. This
-differs from the focus on maximizing the security of an individual mail
-communication. Another major difference in approach is that Autocrypt Level 1
+Autocrypt aims to incrementally replace cleartext e-mail with end-to-end
+encrypted e-mail. It aims to sustainably grow the overall percentage of
+end-to-end encrypted messages relayed via the e-mail provider network.
+This differs from the traditional focus on maximizing the security of an
+individual mail communication. **Sometimes Autocrypt even recommends to
+send cleartext mail even though encryption would be technically
+possible.** This is because of well-known annoyances around "i can't
+read your encrypted mail" situations. Autocrypt is opportunistic
+and tries to stay out of the way of users.
+
+Another difference to traditional approaches is that Autocrypt Level 1
 only defends against passive data collection. Protection against active
 adversaries (those which modify messages in transit) is the aim of
 future specifications. We share and support :rfc:`the new perspective
 stated in RFC7435 ("Opportunistic Security: Some Protection Most of the
 Time") <7435#section-1.2>`.
 
+The Level 1 specification makes it easy for users to encrypt. There are
+no changes required from e-mail providers and there are no dependencies
+on key servers. The spec describes the basic capabilities required for a
+mail app to be Autocrypt-capable at Level 1, allowing it to exchange
+end-to-end encrypted e-mails with other Autocrypt-capable mail apps. For
+those familiar with existing e-mail specs, we use the term "mail app"
+and "MUA" interchangeably throughout the doc.
+
 For ease of implementation and deployment, Level 1 focuses on the use of
-Autocrypt on a single device. Users get basic support for transfering
-secret keys between Autocrypt-capable mail apps. They need to enter a
-long number for securing the transfer, technically realized through
-sending and receiving an e-mail message. We aim to improve the usability
-around secret key sharing in subsequent Autocrypt specifications.
+Autocrypt on a single device. However, users get support for transfering
+Autocrypt secret keys to other devices. They need to enter a
+long number for securing the transfer which is technically realized
+through sending and receiving an e-mail message. We aim to improve
+usability around keeping synchronized Autocrypt state on multiple
+devices in subsequent Autocrypt specifications.
 
 We designed Level 1 to be relatively easy for developers to adopt. There is
-detailed guidance on protocol, internal states and user interface concerns.
+detailed guidance on protocol, internal state and user interface concerns.
 We have a good track record of supporting new implementers. Please
-don't hesitate to ask back and send comments.
+don't hesitate to ask back or send comments.
 
 .. only:: builder_html
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -6,9 +6,6 @@
 Autocrypt Level 1: Enabling encryption, avoiding annoyances
 ===========================================================
 
-Introduction and general design decisions
------------------------------------------
-
 This specification is the result of maybe 2000 hours of talking, testing and
 coding iterations during 2017. Around 20 developers and many more users and
 trainers participated overall in Autocrypt sessions. The majority of these
@@ -20,11 +17,12 @@ Autocrypt aims to incrementally replace cleartext e-mail with end-to-end
 encrypted e-mail. It aims to sustainably grow the overall percentage of
 end-to-end encrypted messages relayed via the e-mail provider network.
 This differs from the traditional focus on maximizing the security of an
-individual mail communication. **Sometimes Autocrypt even recommends to
+individual mail communication. **Sometimes Autocrypt recommends to
 send cleartext mail even though encryption would be technically
 possible.** This is because of well-known annoyances around "i can't
-read your encrypted mail" situations. Autocrypt is opportunistic
-and tries to stay out of the way of users.
+read your encrypted mail" situations. Autocrypt operates opportunistically
+and tries to stay out of the way of users who want to, first of all,
+communicate.
 
 Another difference to traditional approaches is that Autocrypt Level 1
 only defends against passive data collection. Protection against active

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -6,22 +6,41 @@
 Autocrypt Level 1: Enabling encryption, avoiding annoyances
 ===========================================================
 
-Autocrypt makes it easy for people to encrypt email.  This document
-describes the basic capabilities required for a mail app to be
-Autocrypt-capable at Level 1.
+Autocrypt aims to incrementally replace cleartext e-mail with end-to-end
+encrypted e-mail. The Level 1 specification makes it easy for users to
+encrypt by adding neccessary cryptographic information to e-mail messages.
+There are no changes required from e-mail providers and there are no
+dependencies on key servers. The spec describes the basic capabilities
+required for a mail app to be Autocrypt-capable at Level 1, allowing it
+to exchange end-to-end encrypted e-mails with other Autocrypt-capable
+mail apps.
 
-The design of Level 1 is driven by usability concerns and by the
-realities of incremental deployment. A user may mix both
-Autocrypt-enabled MUAs and traditional MUAs, and we'd
-like to avoid annoyances like unexpectedly unreadable mails while also
-supporting users who want to explicitly turn on encryption.
+This specification is the result of maybe 2000 hours of talking and
+coding iterations during 2017. Around 20 people and many more users and
+trainers participated in Autocrypt sessions.  The majority of these
+participants have engaged with the e-mail encryption space for a
+long time. There was overwhelming agreement that fresh approaches focusing
+on usability concerns are needed.
+
+Autocrypt aims to sustainably grow the overall percentage of end-to-end
+encrypted messages relayed via the e-email provider network. This
+differs from the focus on maximizing the security of an individual mail
+communication.  Another major difference in approach is that Autocrypt Level 1
+only defends against passive data collection.  Protection against active
+adversaries (those which modify messages in transit) is the aim of
+future specifications. We share and support :rfc:`the new perspective
+stated in RFC7435 ("Opportunistic Security: Some Protection Most of the
+Time") <7435#section-1.2>`.
 
 For ease of implementation and deployment, Level 1 focuses on the use
-of Autocrypt on a single device.  We intend to :doc:`support
-multi-device synchronization (and other features) as part of Level
-2<next-steps>`.  We want to keep Level 1 simple enough that it's easy
-for developers to adopt it so we can drive efforts from real-life
-experiences as soon as possible.
+of Autocrypt on a single device. It also defines an initial mechanism for
+sharing secret keys between mail apps of a single user. We aim to improve the
+usability of secret key sharing in subsequent Autocrypt specifications.
+
+We designed Level 1 to be relatively easy for developers to adopt. There is
+detailed guidance on the protocol, internal state and usability issues.
+We have a good track record of supporting new implementers.  Please
+don't hesitate to ask back and send comments.
 
 .. only:: builder_html
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -12,7 +12,7 @@ of maximizing the security of individual mail communications.
 **Sometimes Autocrypt recommends to send cleartext mail even though
 encryption appears technically possible.** This is because we want to
 avoid unreadable mail for users. Users may mix both Autocrypt-capable
-and traditional mail apps and they may loose devices or otherwise loose
+and traditional mail apps and they may lose devices or in other ways
 the ability to decrypt in unrecoverable ways. Reverting to cleartext
 when we suspect such situations is a key part of our aim to stay out of
 the way of users.

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -7,13 +7,13 @@ Autocrypt Level 1: Enabling encryption, avoiding annoyances
 ===========================================================
 
 Autocrypt aims to incrementally and carefully replace cleartext e-mail
-with end-to-end encrypted e-mail. This differs from the traditional focus
-on maximizing the security of an individual mail communication.
+with end-to-end encrypted e-mail. This differs from the traditional approach
+of maximizing the security of individual mail communications.
 **Sometimes Autocrypt recommends to send cleartext mail even though
-encryption would seem technically possible.** This is because we want to
+encryption appears technically possible.** This is because we want to
 avoid unreadable mail for users. Users may mix both Autocrypt-capable
 and traditional mail apps and they may loose devices or otherwise loose
-the ability to decrypt in unrecoverable ways.  Reverting to cleartext
+the ability to decrypt in unrecoverable ways. Reverting to cleartext
 when we suspect such situations is a key part of our aim to stay out of
 the way of users.
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -8,7 +8,7 @@ Autocrypt Level 1: Enabling encryption, avoiding annoyances
 
 Autocrypt aims to incrementally replace cleartext e-mail with end-to-end
 encrypted e-mail. The Level 1 specification makes it easy for users to
-encrypt.  There are no changes required from e-mail providers and there
+encrypt. There are no changes required from e-mail providers and there
 are no dependencies on key servers. The spec describes the basic
 capabilities required for a mail app to be Autocrypt-capable at Level 1,
 allowing it to exchange end-to-end encrypted e-mails with other
@@ -33,7 +33,7 @@ Time") <7435#section-1.2>`.
 
 For ease of implementation and deployment, Level 1 focuses on the use of
 Autocrypt on a single device. Users get basic support for transfering
-secret keys between Autocrypt-capable mail apps.  They need to enter a
+secret keys between Autocrypt-capable mail apps. They need to enter a
 long number for securing the transfer, technically realized through
 sending and receiving an e-mail message. We aim to improve the usability
 around secret key sharing in subsequent Autocrypt specifications.


### PR DESCRIPTION
… how it differs from past ones. After hearing some first comments from fresh readers i think it's important to better scope/motivate what we are doing first and also directly name major differences.   This also makes it easy to remain motivated to read things when you are coming from a (very) "pgp-skeptical" experience. This PR also strikes the reference to "next steps" which is a very drafty document (addresses #225).