### PR TITLE
Add numbering to subsections

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -275,7 +275,10 @@ latex_elements = {
 
      # Additional stuff for the LaTeX preamble.
      #
-     'preamble': '\\newcommand{\\autocryptrelease}{'+specversion+'}',
+     'preamble': '''
+\\newcommand{\\autocryptrelease}{'+specversion+'}
+\\setcounter{secnumdepth}{3}
+''',
 
      # Latex figure (float) alignment
      #


### PR DESCRIPTION
This should make it easier to refer to subsections of the document
specifically.