### PR TITLE
never prefer a gossip key over a directly received one. Fixes #248.

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -525,8 +525,7 @@ The first phase computes the ``preliminary-recommendation``.
 Preliminary Recommendation
 __________________________
 
-If either ``public_key`` is ``null``, or ``autocrypt_timestamp`` is
-more than 35 days older than ``gossip_key_timestamp``, set
+If ``public_key`` is ``null``, then set
 ``target-keys[to-addr]`` to ``gossip_key`` and set
 ``preliminary-recommendation`` to ``discourage`` and skip to the
 :ref:`final-recommendation-phase`.


### PR DESCRIPTION
It fixes #248 in the sense that Carol will be able to read half the mails (either the ones from Alice, or the ones from Bob) whereas with the current logic and the #248 scenario Carol can not read mails from neither bob or Alice. IOW,   50% unreadable mail is better than a 100%. Also, there isn't sufficient information for Bob to conclude that Alice's gossiped keys for carol are better than his own.  The date when a key was gossiped does not indicate much. 