### PR TITLE
Eliminate plain text body, as the Email is multipart/encrypted

### DIFF
--- a/doc/appendix/example-gossip.eml
+++ b/doc/appendix/example-gossip.eml
@@ -41,7 +41,6 @@ Content-Type: multipart/encrypted;
  protocol="application/pgp-encrypted";
  boundary="PLdq3hBodDceBdiavo4rbQeh0u8JfdUHL"
 
-This is an OpenPGP/MIME encrypted message (RFC 4880 and 3156)
 --PLdq3hBodDceBdiavo4rbQeh0u8JfdUHL
 Content-Type: application/pgp-encrypted
 Content-Description: PGP/MIME version identification


### PR DESCRIPTION
There should not be a plain text string there.
Also, i'm not sure whether ``MIME-Version: 1.0`` should be in the description and payload parts, as it is in the ``multipart`` part.