### PR TITLE
add note about content-disposition

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -834,10 +834,11 @@ both programmatically and manually.
   the purpose of the message (e.g. ``text/plain`` or ``text/html`` or
   ``multipart/alternative``).
 
-- The second mime part of the message MUST have the content-type
-  ``application/autocrypt-setup``. It consists of the user's
-  ASCII-armored secret key, encrypted in an ASCII-armored :rfc:`RFC
-  4880 Symmetrically Encrypted Data Packet<4880#section-5.7>`
+- The second mime part of the message MUST have Content-Type
+  ``application/autocrypt-setup``, and SHOULD have Content-Disposition
+  of ``attachment``. Its content consists of the user's ASCII-armored
+  secret key, encrypted in an ASCII-armored :rfc:`RFC 4880
+  Symmetrically Encrypted Data Packet<4880#section-5.7>`
 
 - There MAY be text above or below the ASCII-armored encrypted data in
   the second MIME part, which MUST be ignored while processing. This


### PR DESCRIPTION
Alternate suggestion to #265, closing #264 if merged.

This leaves out the part about html filenames, see https://github.com/autocrypt/autocrypt/pull/265#discussion_r154540745 for a rationale