### PR TITLE
make sure parsing stops after the first ascii armor ending delimiter

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -847,10 +847,10 @@ both programmatically and manually.
 
 - The encrypted payload MUST begin with an ASCII-armored :rfc:`RFC
   4880 Transferable Secret Key<4880#section-11.2>`. All trailing data
-  after the ASCII-armor ending delimiter MUST be stripped before
-  processing the secret key. The ASCII-armored secret key SHOULD have
-  an ``Autocrypt-Prefer-Encrypt`` header that contains the current
-  ``accounts[addr].prefer_encrypt`` setting.
+  after the first ASCII-armor ending delimiter MUST be stripped
+  before processing the secret key. The ASCII-armored secret key
+  SHOULD have an ``Autocrypt-Prefer-Encrypt`` header that contains the
+  current ``accounts[addr].prefer_encrypt`` setting.
 
 - The symmetric encryption algorithm used MUST be AES-128.
   The passphrase MUST be the Setup Code (see below), used


### PR DESCRIPTION
This is a slight improvement for handling autocrypt setup messages. See #267 for a discussion