### PR TITLE
Correct the Autocrypt Setup Message's encrypted content

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -838,8 +838,13 @@ both programmatically and manually.
 - The second mime part of the message MUST have Content-Type
   ``application/autocrypt-setup``, and SHOULD have Content-Disposition
   of ``attachment``. Its content consists of the user's ASCII-armored
-  secret key, encrypted in an ASCII-armored :rfc:`RFC 4880
-  Symmetrically Encrypted Data Packet<4880#section-5.7>`
+  secret key, encrypted within an ASCII-armored OpenPGP
+  symmetrically-encrypted message.  Specifically, this means a block
+  delimited with ``-----BEGIN PGP MESSAGE-----`` and ``-----END PGP
+  MESSAGE-----``, which contains two OpenPGP packets: a
+  :rfc:`Symmetric-Key Encrypted Session Key<4880#section-5.3>`
+  followed by a :rfc:`Symmetrically Encrypted Integrity Protected Data
+  Packet<4880#section-5.13>`.
 
 - There MAY be text above or below the ASCII-armored encrypted data in
   the second MIME part, which MUST be ignored while processing. This


### PR DESCRIPTION
OpenPGP's Symmetrically-Encrypted Data Packet has no integrity
protection, and it should never be used.

Furthermore, the setup message should use an SKESK, both to provide
some level of PBKDF2-based key stretching, and to ensure that the
actual symmetric key used is a full-fledged AES-128 key.

This also matches what GnuPG will generate when running ``gpg
--symmetric``.