### PR TITLE
point media inquiries to "press" e-mail alias.

### DIFF
--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -16,9 +16,9 @@ If you want to talk with us you may:
 - join chats at **#autocrypt on freenode** or through `matrix mirror
   <https://riot.im/app/#/room/#autocrypt:matrix.org>`_.
 
-- if you are writing articles or want to more privately talk to project
-  members please mail contact at this website domain. Any technical
-  questions should go to the above public channels instead, though.
+- if you want to more privately talk to project members please mail
+  contact at autocrypt.org. Any technical questions should go to
+  the above public channels instead, though.
 
 .. _`Autocrypt mailing list`: https://lists.mayfirst.org/mailman/listinfo/autocrypt
 

--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -16,6 +16,9 @@ If you want to talk with us you may:
 - join chats at **#autocrypt on freenode** or through `matrix mirror
   <https://riot.im/app/#/room/#autocrypt:matrix.org>`_.
 
+- if you are writing articles or want to more privately talk to project
+  members please mail contact at this website domain. Any technical
+  questions should go to the above public channels instead, though.
 
 .. _`Autocrypt mailing list`: https://lists.mayfirst.org/mailman/listinfo/autocrypt
 

--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -16,9 +16,7 @@ If you want to talk with us you may:
 - join chats at **#autocrypt on freenode** or through `matrix mirror
   <https://riot.im/app/#/room/#autocrypt:matrix.org>`_.
 
-- if you want to more privately talk to project members please mail
-  contact at autocrypt.org. Any technical questions should go to
-  the above public channels instead, though.
+- for media and press related questions please mail press at autocrypt org.
 
 .. _`Autocrypt mailing list`: https://lists.mayfirst.org/mailman/listinfo/autocrypt
 


### PR DESCRIPTION
added an email possibility to contact at the autocrypt domain, which currently comprises dkg, valodim, bjoern and me -- please contact me personally if you want to get added. The alias is hosted on mail.autocrypt.org which i'd like to shift to the autocrypt.org vm proper (along with the bot). 