### PR TITLE
change the 'MUST add and disable-Autocrypt option' to a SHOULD

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -1033,7 +1033,7 @@ encrypt.
 Account Preferences
 +++++++++++++++++++
 
-Level 1 MUAs MUST allow the user to disable Autocrypt completely for
+Level 1 MUAs SHOULD allow the user to disable Autocrypt completely for
 each account they control (that is, to set ``accounts[addr].enabled``
 to ``false``).  For level 1, we expect most MUAs to have Autocrypt
 disabled by default.


### PR DESCRIPTION
Figured out the reason for the MUST on IRC with @dkg:

IIRC, the MUST is there because we don't want people to reject newer versions of MUAs just because they're autocrypt-capable. Maybe people do not want to use Autocrypt eg. in Enigmail and want to be sure, everything is as before.

However, for completely new MUAs, this MUST seems to be not always useful, eg. if the MUAs uses Autocrypt always and by default (eg. Delta Chat).

So I would suggest changing this MUST to a SHOULD so that we can have Autocrypt-always-on clients that do not break the spec.