### PR TITLE
website: put the actual mission first

### DIFF
--- a/doc/_templates/customindex.html
+++ b/doc/_templates/customindex.html
@@ -40,7 +40,14 @@
   <div>
     <h2>Our Mission</h2>
     <p>
-      End-to-end encrypted e-mail has been around for decades, but has failed to see wide adoption outside of specialist communities.  Autocrypt aims to provide encryption convenient enough for much wider adoption. Through strengthening the e-mail ecosystem step-by-step, we want to increase user autonomy and privacy for everyone.
+      Autocrypt aims to provide end-to-end encrypted e-mail that is
+      convenient enough for wide adoption.
+    </p>
+    <p>
+      End-to-end encrypted e-mail has been around for decades, but has
+      failed to see wide adoption outside of specialist communities.
+      Through strengthening the e-mail ecosystem step-by-step, we want
+      to increase user autonomy and privacy for everyone.
     </p>
     <p>
       The Autocrypt effort is driven by a diverse group of mail app developers, hackers and researchers who are willing to take fresh approaches, learn from past mistakes, and collectively aim to increase the overall end-to-end encryption of e-mail in the net.


### PR DESCRIPTION
When making a mission statement, the first sentence should be a simple
and clear statement of our goals.  It should not start with an
explanation of why we haven't reached them yet, or of the historical
background.  Those things are fine to include, but the first sentence
after "Our Mission" should be the mission of the project.