### PR TITLE
address #320 -- shift py-autocrypt implementation to non-organization

### DIFF
--- a/doc/dev-status.rst
+++ b/doc/dev-status.rst
@@ -75,8 +75,6 @@ For developers
 
 Source code:
 
-- `py-autocrypt code <https://github.com/autocrypt/py-autocrypt>`_
-
 - `Enigmail code <https://sourceforge.net/p/enigmail/source/ci/master/tree/>`_
 
 - K9: TODO
@@ -84,6 +82,10 @@ Source code:
 - Mailpile: TODO
 
 - Notmuch/Alot: TODO
+
+- `py-autocrypt (uses gpg) <https://github.com/hpk42/py-autocrypt>`_
+
+- `pyac code (uses pgpy) <https://github.com/juga0/pyac>`
 
 - `Bitmask/LEAP refactorings <https://0xacab.org/leap/bitmask-dev/merge_requests/55/diffs>`_
 

--- a/doc/dev-status.rst
+++ b/doc/dev-status.rst
@@ -79,19 +79,21 @@ Source code:
 
 - K9: TODO
 
+- `Delta.Chat code <https://github.com/deltachat/>`_
+
 - Mailpile: TODO
 
 - Notmuch/Alot: TODO
 
 - `py-autocrypt (uses gpg) <https://github.com/hpk42/py-autocrypt>`_
 
-- `pyac code (uses pgpy) <https://github.com/juga0/pyac>`
+- `pyac <https://github.com/juga0/pyac>`_ (uses `PGPy
+  <https://pgpy.readthedocs.io>`_)
 
 - `Bitmask/LEAP refactorings <https://0xacab.org/leap/bitmask-dev/merge_requests/55/diffs>`_
 
 - `Go Autocrypt <https://github.com/autocrypt/go-autocrypt>`_
 
-- `Delta.Chat code <https://github.com/deltachat/>`_
 
 Testing Autocrypt
 +++++++++++++++++


### PR DESCRIPTION
address #320 -- prepare shift py-autocrypt implementation to non-organization location and mention juga0/pyac as another python supporting autocrypt effort. Accepting this merge be accompanied with moving the py-autocrypt repository. 