### PR TITLE
add technical summary to front page

### DIFF
--- a/doc/_templates/customindex.html
+++ b/doc/_templates/customindex.html
@@ -44,6 +44,13 @@
       end-to-end-encryption of e-mails. Developers are working on
       bringing it to several different e-mail programs.
     </p>
+    <h2>Technical Summary</h2>
+    <p>
+        Autocrypt is a specification that allows e-mail clients to negotiate
+        end-to-end encryption, transparently piggybacking on plaintext e-mails.
+        The goal is to offer single-click opt-in encryption when the user asks
+        for it, but otherwise stay out of their way as much as possible.
+    </p>
     <h2>Does it already work?</h2>
     <p>
       The first specification, <a href="{{ pathto('level1') }}">Level 1</a>,


### PR DESCRIPTION
For a short moment, we were [trending on hacker news](https://news.ycombinator.com/item?id=16088036) :)

People seemed a little confused, and the question came up "but what does it even do??". I added a paragraph that gives a two-sentence exec summary to answer that question better.