### PR TITLE
incremental improvements on @valodim's hotfix last night, aiming for:

### DIFF
--- a/doc/_templates/customindex.html
+++ b/doc/_templates/customindex.html
@@ -40,22 +40,23 @@
   <div>
     <h2>What is Autocrypt?</h2>
     <p>
-      Autocrypt is a set of guidelines for convenient
-      end-to-end-encryption of e-mails. Developers are working on
-      bringing it to several different e-mail programs.
+      Autocrypt is a set of guidelines for developers to achieve
+      convenient end-to-end-encryption of e-mails.
+      It specifies how e-mail programs transparently negotiate and expose
+      end-to-end encryption capabilities to users. 
+
     </p>
-    <h2>Technical Summary</h2>
     <p>
-        Autocrypt is a specification that allows e-mail clients to negotiate
-        end-to-end encryption, transparently piggybacking on plaintext e-mails.
-        The goal is to offer single-click opt-in encryption when the user asks
-        for it, but otherwise stay out of their way as much as possible.
+      <a href="{{ pathto('level1') }}">Autocrypt Level 1</a>
+      offers single-click, opt-in encryption, eases encrypted
+      group communications and provides a way to 
+      setup encryption on multiple devices. 
     </p>
     <h2>Does it already work?</h2>
     <p>
       The first specification, <a href="{{ pathto('level1') }}">Level 1</a>,
       was released in December 2017. A few mail programs are already capable
-      of Autocrypt, some want to be in Spring 2018.
+      of Autocrypt, others want to be during Spring 2018.
     </p>
     <p>
       Please <a href="https://lists.mayfirst.org/pipermail/autocrypt/2017-December/000287.html">


### PR DESCRIPTION
- brevity
- trying to be legible and useful for both end/expert users and
  security-minded hackers

we've had two public waves of interest (first heise, hackernews now) and i
guess we will keep changing/adapting things as tides role in,
and in particular when more mail apps with l1 support are released ...
I think "single-click opt-in encryption" is a useful catchphrase

Moreover, mentioning encrypted group communication and multi-device
support needs to be mentioned, as these are pain
points known to both existing users and developers.

I btw welcome the evolving practise of relatively quick merges --
if we evolve a practise that subsequent PRs can change things
equally easily :)
  