### PR TITLE
be more specific and replace 'piggybacking'

### DIFF
--- a/doc/_templates/customindex.html
+++ b/doc/_templates/customindex.html
@@ -43,7 +43,7 @@
       Autocrypt is a set of guidelines for developers to achieve
       convenient end-to-end-encryption of e-mails.
       It specifies how e-mail programs negotiate encryption
-      capabilities keys using regular e-mails. 
+      capabilities and transfer keys using regular e-mails. 
     </p>
     <p>
       <a href="{{ pathto('level1') }}">Autocrypt Level 1</a>

--- a/doc/_templates/customindex.html
+++ b/doc/_templates/customindex.html
@@ -43,7 +43,7 @@
       Autocrypt is a set of guidelines for developers to achieve
       convenient end-to-end-encryption of e-mails.
       It specifies how e-mail programs negotiate encryption
-      capabilities and transfer keys using regular e-mails. 
+      capabilities using regular e-mails. 
     </p>
     <p>
       <a href="{{ pathto('level1') }}">Autocrypt Level 1</a>

--- a/doc/_templates/customindex.html
+++ b/doc/_templates/customindex.html
@@ -43,7 +43,7 @@
       Autocrypt is a set of guidelines for developers to achieve
       convenient end-to-end-encryption of e-mails.
       It specifies how e-mail programs negotiate encryption
-      capabilities by piggypacking on regular e-mails. 
+      capabilities keys using regular e-mails. 
     </p>
     <p>
       <a href="{{ pathto('level1') }}">Autocrypt Level 1</a>


### PR DESCRIPTION
just in case there weren't enough changes in the past week, here's another two cents.

piggybacking is colloquial and non-native speakers with a lower level will likely have trouble with it.  