### PR TITLE
an attempt at an Autocrypt code of conduct (#352)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,72 @@
+# Autocrypt Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in the Autocrypt
+community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Showing empathy towards community members and newcomers
+* Helping and mediating in cases of upsets or conflict
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other behaviour which could reasonably be considered inappropriate in a
+  professional setting
+
+## Maintainers and Responsibilities
+
+Project maintainers are those with commit rights to the Autocrypt specification.
+Each maintainer is asked to take responsibility and appropriate action in response
+to witnessed instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project communication channels and
+gatherings as well as in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting select project maintainers, currently azul@autocrypt.org
+and compl4xx@autocrypt.org -- they are also often on the IRC #autocrypt channel
+on freenode. They will review reports and involve other maintainers as appropriate,
+resulting in a response that is deemed neccessary and appropriate to the circumstances.
+Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+Project maintainers who do not follow the Code of Conduct in good faith
+may face temporary or permanent repercussions as determined by other
+maintainers.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,12 +1,13 @@
-# Autocrypt Community Code of Conduct
-
-## Our Pledge
+Autocrypt Community Code of Conduct
+===================================
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers strive to making participation in the Autocrypt
-community a pleasurable, harassment-free experience. 
+community a pleasurable, harassment-free experience.
 
-## Our Standards
+
+Our Standards
+-------------
 
 Examples of behavior that contribute to creating a positive environment include:
 
@@ -27,23 +28,26 @@ Examples of behavior which we ask everybody to avoid include:
   professional setting
 
 We recognize that sometimes people may have a bad day, or be unaware of
-the impact of their behaviour. When that happens, you may carefully remind 
+the impact of their behaviour. When that happens, you may carefully remind
 them in public or private, whatever is more appropriate. Assume good faith;
 it's more likely that participants are unaware than that they intentionally
 try to denigrade others or the quality of the discussion.
 
-## Maintainers and Responsibilities
+
+Maintainers and Responsibilities
+--------------------------------
 
 Project maintainers are those with commit rights to the Autocrypt specification.
-Each maintainer is asked to take responsibility and appropriate, careful action 
+Each maintainer is asked to take responsibility and appropriate, careful action
 in response to witnessed instances of questionable behavior.
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct.
-They may also ban temporarily or permanently a contributor for 
+They may also ban temporarily or permanently a contributor for
 other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
-## Scope
+Scope
+-----
 
 This Code of Conduct applies both within project communication channels and
 gatherings as well as in public spaces
@@ -52,7 +56,8 @@ representing a project or community include using an official project e-mail
 address, posting via an official social media account, or acting as an
 representative at an online or offline event.
 
-## Reporting and Responses
+Reporting and Responses
+-----------------------
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting select project maintainers, currently azul@autocrypt.org
@@ -62,7 +67,9 @@ resulting in a response that is deemed neccessary and appropriate to the circums
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident. Maintainers are themselves not exempt from being reported about and may face
 temporary or permanent repercussions as determined by other maintainers.
 
-## Attribution
+
+Attribution
+-----------
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
 available at [http://contributor-covenant.org/version/1/4][version]

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -2,7 +2,7 @@ Autocrypt Community Code of Conduct
 ===================================
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers strive to making participation in the Autocrypt
+contributors and maintainers strive to make participation in the Autocrypt
 community a pleasurable, harassment-free experience.
 
 
@@ -27,11 +27,11 @@ Examples of behavior which we ask everybody to avoid include:
 * Other behaviour which could reasonably be considered inappropriate in a
   professional setting
 
-We recognize that sometimes people may have a bad day, or be unaware of
+We recognize that sometimes people may have a bad day, or may be unaware of
 the impact of their behaviour. When that happens, you may carefully remind
 them in public or private, whatever is more appropriate. Assume good faith;
-it's more likely that participants are unaware than that they intentionally
-try to denigrade others or the quality of the discussion.
+it's more likely that participants are unaware than that they are intentionally
+trying to denigrate others or reduce the quality of discussion.
 
 
 Maintainers and Responsibilities
@@ -61,7 +61,7 @@ Reporting and Responses
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting select project maintainers, currently azul@autocrypt.org
-and compl4xx@autocrypt.org -- they are also often on the IRC #autocrypt channel
+and compl4xx@autocrypt.org -- they are also often on the IRC `#autocrypt` channel
 on freenode. They will review reports and involve other maintainers as appropriate,
 resulting in a response that is deemed neccessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident. Maintainers are themselves not exempt from being reported about and may face

--- a/doc/_templates/globaltoc.html
+++ b/doc/_templates/globaltoc.html
@@ -21,6 +21,7 @@
       <li><a href="{{ pathto('dev-status') }}">Implementation Status</a></li>
       <li><a href="{{ pathto('examples') }}">Example Mail Flows</a></li>
       <li><a href="{{ pathto('background') }}">Project Background</a></li>
+      <li><a href="{{ pathto('code_of_conduct') }}">Code of Conduct</a></li>
       <li><a href="{{ pathto('faq') }}">FAQ</a></li>
       <li><a href="{{ pathto('contents') }}">All Docs</a></li>
     </ul>

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -45,6 +45,7 @@ and contributors, MUA developers and privacy enthusiasts.
 
    background
    contact
+   code_of_conduct
    examples
    level1
    glossary


### PR DESCRIPTION
mostly based on https://www.contributor-covenant.org/version/1/4/code-of-conduct.html but modified a bit:

- defining who maintainers are: those with commit rights to the spec, this is public in github

- asking each maintainer to act (decentralized if you will) and not focusing everything on a centralized "enforcement"

- naming two specific people in cases where the above does not work ...
  didn't ask the two but hereby nominate them.  In any case, I prefer naming two
  individuals to an abstract "contact" or "maintainers" list where especially
  newcomers may not know if the problem they are reporting
  involves a person on that list.