### PR TITLE
amendments to CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -19,9 +19,9 @@ Examples of behavior that contributes to creating a positive environment include
 * Showing empathy towards community members and newcomers
 * Helping and mediating in cases of upsets or conflict
 
-Examples of unacceptable behavior include:
+Please think twice, before you do something like this, as it may hurt people:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Using sexualized language or imagery and unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
@@ -57,7 +57,9 @@ reported by contacting select project maintainers, currently azul@autocrypt.org
 and compl4xx@autocrypt.org -- they are also often on the IRC #autocrypt channel
 on freenode. They will review reports and involve other maintainers as appropriate,
 resulting in a response that is deemed neccessary and appropriate to the circumstances.
-Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+Maintainers are obligated to maintain confidentiality with regard to the reporter
+of an incident. They should as well believe a reporter, and respect their experience
+and perspective.
 
 Project maintainers who do not follow the Code of Conduct in good faith
 may face temporary or permanent repercussions as determined by other


### PR DESCRIPTION
add awareness principle of believing victims, also weakening the unacceptable behavior part.

People who handle awareness cases should believe the reporters; victims have to be sure that they are taken seriously. There is a long history of authorities questioning the perspective of sexual assault victims. Victims are seen as "too emotional", so their opinion & bodily autonomy can be disregarded. That's why a community, which cares for everyone's bodily autonomy, has to believe someone, if they report an incident like this. The decision still lies with the maintainer who handles the case, and their judgement.

I also weakened the part about "this behavior is unacceptable"; I want to appeal to the good sides of people, not their bad sides. Most cases can be solved by mediation, empathy, and similar techniques. I suggest this wording because we don't want to invoke a conflict before it arises. People tend to feel provoked by wordings like "unacceptable behavior".