### PR TITLE
some what i consider careful improvements to the CoC after IRC discus…

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,17 +1,14 @@
-# Autocrypt Code of Conduct
+# Autocrypt Community Code of Conduct
 
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in the Autocrypt
-community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+contributors and maintainers strive to making participation in the Autocrypt
+community a pleasurable, harassment-free experience. 
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment include:
+Examples of behavior that we think contributes to creating a positive environment include:
 
 * Using welcoming and inclusive language
 * Being respectful of differing viewpoints and experiences
@@ -19,7 +16,7 @@ Examples of behavior that contributes to creating a positive environment include
 * Showing empathy towards community members and newcomers
 * Helping and mediating in cases of upsets or conflict
 
-Examples of unacceptable behavior include:
+Examples of behavior which we ask everybody to avoid include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
@@ -29,17 +26,22 @@ Examples of unacceptable behavior include:
 * Other behaviour which could reasonably be considered inappropriate in a
   professional setting
 
+We recognize that sometimes people may have a bad day, or be unaware of
+the impact of their behaviour. When that happens, you may carefully remind 
+them in public or private, whatever is more appropriate. Assume good faith;
+it's more likely that participants are unaware than that they intentionally
+try to denigrade others or the quality of the discussion.
+
 ## Maintainers and Responsibilities
 
 Project maintainers are those with commit rights to the Autocrypt specification.
-Each maintainer is asked to take responsibility and appropriate action in response
-to witnessed instances of unacceptable behavior.
-
+Each maintainer is asked to take responsibility and appropriate, careful action 
+in response to witnessed instances of questionable behavior.
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+that violate "Our Standards" above. 
+They may also ban temporarily or permanently a contributor for 
+other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
@@ -50,18 +52,15 @@ representing a project or community include using an official project e-mail
 address, posting via an official social media account, or acting as an
 representative at an online or offline event.
 
-## Enforcement
+## Reporting and Responses
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting select project maintainers, currently azul@autocrypt.org
 and compl4xx@autocrypt.org -- they are also often on the IRC #autocrypt channel
 on freenode. They will review reports and involve other maintainers as appropriate,
 resulting in a response that is deemed neccessary and appropriate to the circumstances.
-Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
-
-Project maintainers who do not follow the Code of Conduct in good faith
-may face temporary or permanent repercussions as determined by other
-maintainers.
+Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident. Maintainers are themselves not exempt from being reported about and may face
+temporary or permanent repercussions as determined by other maintainers.
 
 ## Attribution
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,7 +8,7 @@ community a pleasurable, harassment-free experience.
 
 ## Our Standards
 
-Examples of behavior that we think contributes to creating a positive environment include:
+Examples of behavior that contribute to creating a positive environment include:
 
 * Using welcoming and inclusive language
 * Being respectful of differing viewpoints and experiences
@@ -39,7 +39,7 @@ Each maintainer is asked to take responsibility and appropriate, careful action
 in response to witnessed instances of questionable behavior.
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
-that violate "Our Standards" above. 
+that are not aligned to this Code of Conduct.
 They may also ban temporarily or permanently a contributor for 
 other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 


### PR DESCRIPTION
…sions:

- substitute one "pledge" with "strive" but the headline is still
  "pledge".

- add "pleasurable" to "harassment-free" to not purely define things
  negatively

- add a "bad-day" paragraph to "Our standards"

- substitute internal references to "Code of Conduct" as i don't
  like the term. It's only the super-heading of everything
  because people came to expect to look for this term.

- substitute "enforcement" with "reporting and responses"
  as enforcement has a very police-like sound to me
  which i think is inappropriate here.