### PR TITLE
draft for discussion: Autocrypt-Draft-State header

### DIFF
--- a/doc/appendix/example-draft-cleartext.eml
+++ b/doc/appendix/example-draft-cleartext.eml
@@ -1,0 +1,23 @@
+Autocrypt-Gossip: addr=bob@autocrypt.example; keydata=
+ mDMEXEcE6RYJKwYBBAHaRw8BAQdAPPy13Q7Y8w2VPRkksrijrn9o8u59ra1c2CJiHFpbM2G0FWJ
+ vYkBhdXRvY3J5cHQuZXhhbXBsZYiWBBMWCAA+FiEE8FQeqC0xAKoa3zse4w5v3UWQH4IFAlxHBO
+ kCGwMFCQPCZwAFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ4w5v3UWQH4IfwAEA3lujohz3N
+ j9afUnaGUXN7YboIzQsmpgGkN8thyb/slIBAKwdJyg1SurKqHnxy3Wl/DBzOrR12/pN7nScn0+x
+ 4sgBuDgEXEcE6RIKKwYBBAGXVQEFAQEHQJSU7QErtJOYXsIagw2qwnVbt31ooVEx8Xcb476NCbF
+ jAwEIB4h4BBgWCAAgFiEE8FQeqC0xAKoa3zse4w5v3UWQH4IFAlxHBOkCGwwACgkQ4w5v3UWQH4
+ LlHQEAlwUBfUU8ORC0RAS/dzlZSEm7+ImY12Wv8QGUCx5zPbUA/3YH84ZOAQDbmV/C+R//0WVNb
+ Gfav9X5KYmiratYR7oL
+Content-Type: text/plain
+
+Hi Bob,
+
+this is a message where I'm not sure yet what to write. I'll just
+store it as a draft for now!
+
+My other Autocrypt-enabled MUA should be able to pick this message up
+and see from the Autocrypt-Draft-State header that I chose to encrypt
+here.  It will also have the key I would have used to encrypt if I had
+sent the message, from the contained Autocrypt-Gossip header.
+
+Regards,
+Alice

--- a/doc/appendix/example-draft.eml
+++ b/doc/appendix/example-draft.eml
@@ -1,0 +1,47 @@
+From: Alice <alice@autocrypt.example>
+To: Bob <bob@autocrypt.example>
+Subject: an example of a Draft
+Date: Wed, 30 Jan 2019 18:48:38 +0100
+Message-ID: <1b6828d5-61d5-40b4-8b42-bc318cfd2ad9@autocrypt.example>
+MIME-Version: 1.0
+Autocrypt-Draft-State: encrypt=yes; _by-choice=yes;
+Content-Type: multipart/encrypted;
+ protocol="application/pgp-encrypted";
+ boundary="PLdq3hBodDceBdiavo4rbQeh0u8JfdUHL"
+
+--PLdq3hBodDceBdiavo4rbQeh0u8JfdUHL
+Content-Type: application/pgp-encrypted
+Content-Description: PGP/MIME version identification
+
+Version: 1
+
+--PLdq3hBodDceBdiavo4rbQeh0u8JfdUHL
+Content-Type: application/octet-stream; name="encrypted.asc"
+Content-Description: OpenPGP encrypted message
+Content-Disposition: inline; filename="encrypted.asc"
+
+-----BEGIN PGP MESSAGE-----
+
+hF4DR2b2udXyHrYSAQdAqrEPggVyWpa1o8ovaiGxNRno4EB+7XP5lkMxAEFNMhMw
+oWXMEd8zjKpQpj5sZaJrBr4bsaNxiMfR2TymbPRQi0W+1u56oadPIl0MFgAPT6QC
+0ukBOZNFzVRrUg3stbyAIV9XCNLovJZoju/byynmJlBfYyOIDxU+XTVY5yMfgZO/
+gyy86/K2KcInboE6rLGOCl4V2xCpOby1FLlIxeykRKxWNSKbkGYzwlN3zluMCm3n
++JUxX5a4kLKcXnjmEcxkKyel9JM0TPlepWko6kFCQKIlYwZ9cL+A7ANyqEG5Z0zq
+ekebjcsKcU/v8LRsxXaCQ7zI//gFVOBgP1MwoHprG2y48ZaD32BcYyRqAXgGPd8/
+2GRQrAuqM2rENDVmKNwKibmT2UpgWESaisNof7PhaBpjBIJzoZYwkaeBNvDioR7m
+ddW4FPYfhFcHOK3JF+YRC/IhWzMLqWet4N77gMSUEc5EJye1OXcGl09m6RsG0oMH
+JWuJxoLLKfG3kuzGCgeInjsPIaA5DOEMcWF9B452f/y0LpmD5w+sHksIGYiy0SpU
+s4eFUvxiAeMqp1u7NhK95Ywqlq4IzLm/F2aJ/JVaQQiK7N8aZC7IWrwscgfBRYo7
+7mW2KI5XQknwVDGLCed4zQfBGId27xDzZTQqrWxFY4aYuzCemtMmWF9acEX+mzqg
+T6IVnaScYziPbJbiFvXtb0IcpzZ/jb8Rdv0ddPNXJU8KDgwNDDgdJTRafGh599EH
+hIZNDTtLnTT9EdIbZQv3C4yHwXt94j2cEID6o8CnUaps38BKo5O5KcDgRKERf1F7
+9rlkHyxFRIxihAI8HPE3RyhmrNeyg/Bf4c0sLo4k1H6YmSdqi/JO3vVpbtHajb9P
+YaMwvHqUKjdix0ZnEhYvj8bEE6QqLyfS0jvGDETuIqi5IEjAECFEDxMW4kJb9DHW
+iV9NlMCfd1x+lr8DW2xEx/ojIB05OWaups30b32ZwzuYUcj5o6X4oUdCHy8qnk1R
+NjjFWNqoX7kH9MviFiwFPZJGUQpeCudMa3YCwrboa8vX+zezZ7hFG0HiGhjAlVIr
+IgiQMppKfbz8rsoGzBgO8WkJcpv7sSO8KqLRVH2zMSWPqLGZ7Ywmtk7mho7TpIBv
+UIunM57wgZWWSZQfd/A=
+=gXrd
+-----END PGP MESSAGE-----
+
+--PLdq3hBodDceBdiavo4rbQeh0u8JfdUHL--

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -771,10 +771,11 @@ all of which have a binary value of ``yes`` or ``no``:
 * The critical ``encrypt`` attribute specifies whether the message would
   be sent encrypted or not, at the time of saving the draft. It MUST
   be present in the header.
-* The non-critical ``_is-reply`` attribute indicates whether the message
-  is composed as a reply to an encrypted message. This affects the
-  :ref:`Autocrypt recommendation<final-recommendation-phase>`. It is
-  optional and defaults to ``no``.
+* The non-critical ``_is-reply-to-encrypted`` attribute indicates
+  whether the message is composed as a reply to an encrypted message.
+  This affects the :ref:`Autocrypt
+  recommendation<final-recommendation-phase>`. It is optional and
+  defaults to ``no``.
 * The non-critical ``_by-choice`` attribute indicates whether the value
   of the ``encrypt`` attribute was made by immediate user choice. It is
   optional and defaults to ``no``.

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -710,6 +710,8 @@ To avoid leaking metadata about a third party in the clear, an
 ``Autocrypt-Gossip`` header SHOULD NOT be added outside an encrypted
 MIME part.
 
+.. _key-gossip-update:
+
 Updating Autocrypt Peer State from Key Gossip
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -778,6 +780,26 @@ all of which have a binary value of `yes` or `no`:
 Example::
 
     Autocrypt-Draft-State: encrypt=yes; _by-choice=yes;
+
+Autocrypt Gossip headers for drafts
++++++++++++++++++++++++++++++++++++
+
+When opening a draft that indicates it should be encrypted when sent
+via the ``Autocrypt-Draft-State`` header, the resuming MUA might be
+lacking keys for recipients that were originally available when the
+draft was stored.
+
+To solve this problem, a MUA MAY make use of the `Autocrypt
+Gossip<autocryt-gossip>` mechanism to include the keys of intended
+recipients in the draft message. To do so, it simply places one
+``Autocrypt-Gossip`` header per recipient in the MIME header of the
+encrypted payload of the draft.
+
+Conversely, when opening a draft, a MUA MAY import keys from
+``Autocrypt-Gossip`` headers that are present in the MIME headers of
+the encrypted payload.  These headers should update the ``gossip_key``
+and ``gossip_timestamp`` fields of the relevant peers `as
+usual<autocryt-gossip-update>`.
 
 .. _account-management:
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -735,7 +735,7 @@ way:
    ``keydata`` attribute.
 
 Message Drafts
--------------
+--------------
 
 During message composition, the user may want to close the dialog and
 resume composition at a later point.  To preserve the session state,
@@ -783,6 +783,11 @@ all of which have a binary value of ``yes`` or ``no``:
 Example::
 
     Autocrypt-Draft-State: encrypt=yes; _by-choice=yes;
+
+The semantics of this header are defined only in the context of
+a message that is loaded as a draft. It SHOULD NOT be processed for
+messages loaded in any other context. It MUST be stripped from
+a message before it is sent.
 
 .. note::
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -758,25 +758,25 @@ Storing Draft State
 +++++++++++++++++++
 
 To store information about whether a message should be encrypted when
-sent, an `Autocrypt-Draft-State` header MAY be added to the draft when
+sent, an ``Autocrypt-Draft-State`` header MAY be added to the draft when
 it is stored.
 
-The `Autocrypt-Draft-State` header consists of a list of attributes
+The ``Autocrypt-Draft-State`` header consists of a list of attributes
 with the same syntax as the :ref:`Autocrypt header<autocrypt-header>`
 itself, which also supports critical and non-critical attributes
 following the same semantics.  There are three defined attributes,
-all of which have a binary value of `yes` or `no`:
+all of which have a binary value of ``yes`` or ``no``:
 
-* The critical `encrypt` attribute specifies whether the message would
+* The critical ``encrypt`` attribute specifies whether the message would
   be sent encrypted or not, at the time of saving the draft. It MUST
   be present in the header.
-* The non-critical `_is-reply` attribute indicates whether the message
+* The non-critical ``_is-reply`` attribute indicates whether the message
   is composed as a reply to an encrypted message. This affects the
   :ref:`Autocrypt recommendation<final-recommendation-phase>`. It is
-  optional and defaults to `no`.
-* The non-critical `_by-choice` attribute indicates whether the value
-  of the `encrypt` attribute was made by immediate user choice. It is
-  optional and defaults to `no`.
+  optional and defaults to ``no``.
+* The non-critical ``_by-choice`` attribute indicates whether the value
+  of the ``encrypt`` attribute was made by immediate user choice. It is
+  optional and defaults to ``no``.
 
 Example::
 
@@ -784,9 +784,11 @@ Example::
 
 .. note::
 
-    It would be desirable to store this header in the encrypted
-    payload.  This is missing here because of technical limitations in
-    some MUAs.
+    To minimize the amount of exposed metadata, it would be desirable
+    to store this header in the encrypted payload of the message,
+    rather than its outer envelope.  However, this causes technical
+    difficulties in some MUAs, which is why it is left out here to
+    optimize for interoperability.
 
 Autocrypt Gossip headers for drafts
 +++++++++++++++++++++++++++++++++++
@@ -796,17 +798,17 @@ via the ``Autocrypt-Draft-State`` header, the resuming MUA might be
 lacking keys for recipients that were originally available when the
 draft was stored.
 
-To solve this problem, a MUA MAY make use of the `Autocrypt
-Gossip<autocryt-gossip>` mechanism to include the keys of intended
-recipients in the draft message. To do so, it simply places one
-``Autocrypt-Gossip`` header per recipient in the MIME header of the
-encrypted payload of the draft.
+To solve this problem, a MUA MAY make use of the :ref:`key-gossip`
+mechanism to include the keys of intended recipients in the draft
+message. To do so, it simply places one ``Autocrypt-Gossip`` header
+per recipient in the MIME header of the encrypted payload of the
+draft.
 
 Conversely, when opening a draft, a MUA MAY import keys from
 ``Autocrypt-Gossip`` headers that are present in the MIME headers of
 the encrypted payload.  These headers should update the ``gossip_key``
 and ``gossip_timestamp`` fields of the relevant peers `as
-usual<autocryt-gossip-update>`.
+usual<key-gossip-update>`.
 
 .. _account-management:
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -748,17 +748,18 @@ recipients) before uploading.  It MUST encrypt in this way if the
 message is going to be sent encrypted, and SHOULD encrypt if the user
 might decide to encrypt at a later point, or otherwise keep the draft
 local only.  Drafts encrypted in this way SHOULD be stored in PGP/MIME
-format, and SHOULD NOT be signed.
+format.
+
+To allow storage of drafts independently from the user's secret key,
+encrypted drafts do not need to be signed.  Conversely, a MUA SHOULD
+ignore the signature status of encrypted drafts.
 
 Storing Draft State
 +++++++++++++++++++
 
 To store information about whether a message should be encrypted when
 sent, an `Autocrypt-Draft-State` header MAY be added to the draft when
-it is stored. If the draft is stored encrypted, this header SHOULD be
-put in the MIME header of the encrypted payload, rather than the
-message header. When loading a draft from storage, the header in the
-encrypted payload MUST be preferred to an outer one.
+it is stored.
 
 The `Autocrypt-Draft-State` header consists of a list of attributes
 with the same syntax as the :ref:`Autocrypt header<autocrypt-header>`
@@ -780,6 +781,12 @@ all of which have a binary value of `yes` or `no`:
 Example::
 
     Autocrypt-Draft-State: encrypt=yes; _by-choice=yes;
+
+.. note::
+
+    It would be desirable to store this header in the encrypted
+    payload.  This is missing here because of technical limitations in
+    some MUAs.
 
 Autocrypt Gossip headers for drafts
 +++++++++++++++++++++++++++++++++++

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -734,7 +734,7 @@ way:
 4. Set ``peers[gossip-addr].gossip_key`` to the value of the
    ``keydata`` attribute.
 
-E-Mail Drafts
+Message Drafts
 -------------
 
 During message composition, the user may want to close the dialog and
@@ -750,16 +750,17 @@ might decide to encrypt at a later point, or otherwise keep the draft
 local only.  Drafts encrypted in this way SHOULD be stored in PGP/MIME
 format.
 
-To allow storage of drafts independently from the user's secret key,
-encrypted drafts do not need to be signed.  Conversely, a MUA SHOULD
-ignore the signature status of encrypted drafts.
+A MUA SHOULD ignore the signature status of encrypted drafts, and
+conversely encrypted drafts do not need to be signed.  This allows
+storage of drafts independently from the user's secret key.
+
 
 Storing Draft State
 +++++++++++++++++++
 
 To store information about whether a message should be encrypted when
-sent, an ``Autocrypt-Draft-State`` header MAY be added to the draft when
-it is stored.
+sent, an ``Autocrypt-Draft-State`` header MAY be added to the MIME
+header of the draft message when it is stored.
 
 The ``Autocrypt-Draft-State`` header consists of a list of attributes
 with the same syntax as the :ref:`Autocrypt header<autocrypt-header>`

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -1405,6 +1405,8 @@ high-level overview of what changed between revisions.
 version 1.1
    - change required algorithms and recommendation for key generation
      to Ed25519+Cv25519
+   - add Autocrypt-Draft-State header to preserve encryption state of
+     drafts
 
 version 1.0.1
    - added Terminology section

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -754,6 +754,7 @@ A MUA SHOULD ignore the signature status of encrypted drafts, and
 conversely encrypted drafts do not need to be signed.  This allows
 storage of drafts independently from the user's secret key.
 
+.. _autocrypt-draft-state:
 
 Storing Draft State
 +++++++++++++++++++
@@ -1393,6 +1394,24 @@ contains:
 .. literalinclude:: appendix/example-setup-message-cleartext.key
     :language: none
 
+Example Stored Draft
+++++++++++++++++++++
+
+Alice composes a message to Bob, and manually chooses to encrypt in
+her MUA's UI. She does not send the message immediately, but stores it
+in a drafts folder. The message is encrypted (but not signed), and its
+encryption-related state is saved in the Autocrypt-Draft-Header (see
+:ref:`_autocrypt-draft-state`). The encrypted payload also contains
+Bob's key as an Autocrypt-Gossip header, to ensure encryption is
+possible when the message is picked up.
+
+.. literalinclude:: appendix/example-draft.eml
+    :language: none
+
+The encrypted payload contains:
+
+.. literalinclude:: appendix/example-draft-cleartext.eml
+    :language: none
 
 Document History
 ++++++++++++++++

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -634,16 +634,6 @@ When encrypting, the MUA MUST construct the encrypted message as a
 key, and encrypted to the currently known Autocrypt key of each
 recipient, as well as the sender's Autocrypt key.
 
-E-mail Drafts
-~~~~~~~~~~~~~
-
-For messages that are going to be encrypted when sent, the MUA MUST
-take care to not leak the cleartext of drafts or other
-partially composed messages to their e-mail provider (e.g., in the
-"Drafts" folder). If there is a chance that a message could be
-encrypted, the MUA SHOULD encrypt the draft only to itself before storing
-it remotely. The MUA SHOULD NOT sign drafts.
-
 
 Cleartext replies to encrypted messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -742,6 +732,52 @@ way:
 4. Set ``peers[gossip-addr].gossip_key`` to the value of the
    ``keydata`` attribute.
 
+E-Mail Drafts
+-------------
+
+During message composition, the user may want to close the dialog and
+resume composition at a later point.  To preserve the session state,
+messages are typically saved as "Drafts" in a special folder.
+Messages from this folder may also be resumed from a different MUA.
+
+To prevent the cleartext of a message draft from leaking to the
+provider, the MUA can encrypt the draft message to itself (but not the
+recipients) before uploading.  It MUST encrypt in this way if the
+message is going to be sent encrypted, and SHOULD encrypt if the user
+might decide to encrypt at a later point, or otherwise keep the draft
+local only.  Drafts encrypted in this way SHOULD be stored in PGP/MIME
+format, and SHOULD NOT be signed.
+
+Storing Draft State
++++++++++++++++++++
+
+To store information about whether a message should be encrypted when
+sent, an `Autocrypt-Draft-State` header MAY be added to the draft when
+it is stored. If the draft is stored encrypted, this header SHOULD be
+put in the MIME header of the encrypted payload, rather than the
+message header. When loading a draft from storage, the header in the
+encrypted payload MUST be preferred to an outer one.
+
+The `Autocrypt-Draft-State` header consists of a list of attributes
+with the same syntax as the :ref:`Autocrypt header<autocrypt-header>`
+itself, which also supports critical and non-critical attributes
+following the same semantics.  There are three defined attributes,
+all of which have a binary value of `yes` or `no`:
+
+* The critical `encrypt` attribute specifies whether the message would
+  be sent encrypted or not, at the time of saving the draft. It MUST
+  be present in the header.
+* The non-critical `_is-reply` attribute indicates whether the message
+  is composed as a reply to an encrypted message. This affects the
+  :ref:`Autocrypt recommendation<final-recommendation-phase>`. It is
+  optional and defaults to `no`.
+* The non-critical `_by-choice` attribute indicates whether the value
+  of the `encrypt` attribute was made by immediate user choice. It is
+  optional and defaults to `no`.
+
+Example::
+
+    Autocrypt-Draft-State: encrypt=yes; _by-choice=yes;
 
 .. _account-management:
 


### PR DESCRIPTION
Hey there,

following up on [this thread](https://lists.mayfirst.org/pipermail/autocrypt/2018-April/000325.html) on the mailing list, I wrote a proposal with my current thoughts on this, mostly to have something concrete to discuss and be able to comment line-wise.

A couple of points:

* I went with an Autocrypt specific header, rather than an OpenPGP one. The main reason for this is that a generic OpenPGP header would have to operate in a much broader and less understood context. It's also convenient to be able to reuse the autocrypt header attribute-list format with critical and non-critical attributes.

* The header is designed to be minimal and compatible: The most simple implementation just needs to parse whether "encrypt" is yes or no. Building on that, they can pick up the non-critical attributes.

* This is so far missing a mention of additional possible attributes `_sign-only` and `_encrypt-only`. We don't treat those states in Autocrypt itself, and clients can simply use their own non-critical attributes to store custom data. It still makes sense to mention those two (in a note, perhaps?) with a short description of their semantics, to avoid implementations coming up with different names for them.

* I'd like to have an attribute `_pgp-inline`. In K-9, when replying to a pgp/inline message, the reply will automatically be sent as pgp/inline as well, which is important for compatibility with some MUAs, particularly browser extensions. However, I noticed that Autocrypt actually says messages MUST be sent as PGP/MIME. We should probably reopen that discussion, possibly turn that into a SHOULD and give some guidance on how to handle PGP/INLINE rather than pushing clients into breaking an impractical MUST.