### PR TITLE
Clarifications about user ids in key gossip

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -678,9 +678,9 @@ each of which:
   for how this key is selected.
 
 - If a key has multiple user ids, only one SHOULD be contained in
-  ``keydata``.  If present, that user id SHOULD match the ``addr``
-  attribute.  This is only relevant for keys which came from or were
-  merged with data from external sources.
+  ``keydata``.  This user id SHOULD be picked to match the ``addr``
+  attribute, if possible.  This is only relevant for keys which came
+  from or were merged with data from external sources.
 
 - SHOULD NOT include a ``prefer-encrypt`` attribute.
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -677,9 +677,10 @@ each of which:
   referenced by ``addr``. See also :ref:`preliminary recommendation`
   for how this key is selected.
 
-- SHOULD contain only a single user id in the key material from the
-  ``keydata`` attribute, which matches the ``addr`` attribute. This
-  avoids leaking unrelated identities between recipients.
+- If a key has multiple user ids, only one SHOULD be contained in
+  ``keydata``.  If present, that user id SHOULD match the ``addr``
+  attribute.  This is only relevant for keys which came from or were
+  merged with data from external sources.
 
 - SHOULD NOT include a ``prefer-encrypt`` attribute.
 

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -677,6 +677,10 @@ each of which:
   referenced by ``addr``. See also :ref:`preliminary recommendation`
   for how this key is selected.
 
+- SHOULD contain only a single user id in the key material from the
+  ``keydata`` attribute, which matches the ``addr`` attribute. This
+  avoids leaking unrelated identities between recipients.
+
 - SHOULD NOT include a ``prefer-encrypt`` attribute.
 
 To avoid leaking metadata about a third party in the clear, an

--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -654,10 +654,10 @@ included in the encrypted payload. This does not include BCC
 recipients, which by definition must not be revealed to other
 recipients.
 
-The ``Autocrypt-Gossip`` header has the format as the ``Autocrypt``
-header (see `autocryptheaderformat`_). Its ``addr`` attribute
-indicates the recipient address this header is valid for as usual, but
-may relate to any recipient in the ``To`` or ``Cc`` header.
+The ``Autocrypt-Gossip`` header has the same format as the
+``Autocrypt`` header (see `autocryptheaderformat`_). Its ``addr``
+attribute indicates the recipient address this header is valid for as
+usual, but may relate to any recipient in the ``To`` or ``Cc`` header.
 See example in :ref:`autocrypt-gossip-example`
 
 Key Gossip Injection in Outbound Mail


### PR DESCRIPTION
I found that the gossip section doesn't make it explicit that only the relevant user ids should be sent in gossip headers. This is only a practical consideration: in a pure autocrypt client it wouldn't come up, but actual implementations tend to merge keys that have the same fingerprints. For that reason, it should be ensured that user ids other than the relevant one (from the `addr` attribute) are stripped.