### PR TITLE
Add terminology for key words used to indicate requirement levels

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -59,6 +59,16 @@ both bugfix and backward-compatible feature releases.
    \sphinxtableofcontents
    \newpage
 
+Terminology
+-----------
+
+Key words to indicate requirement levels
+++++++++++++++++++++++++++++++++++++++++
+
+The definition of uppercase key words used in this document to indicate requirement
+levels (e.g. MAY, SHOULD) is stated in :rfc:`RFC 2119 "Key words for use in RFCs 
+to Indicate Requirement Levels"<2119>`.
+
 Overview
 --------
 


### PR DESCRIPTION
fixes #381 
The update to RFC 2119 that states that RFC 2119 is only regarding uppercase key words, is [RFC 8174 "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"](https://tools.ietf.org/html/rfc8174)