### PR TITLE
Add terminology for requirement level keywords

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -59,6 +59,17 @@ both bugfix and backward-compatible feature releases.
    \sphinxtableofcontents
    \newpage
 
+Terminology
+-----------
+
+Keywords to indicate requirement levels
++++++++++++++++++++++++++++++++++++++++++
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL"
+in this document are to be interpreted as described in
+:rfc:`RFC 2119 "Key words for use in RFCs to Indicate Requirement Levels"<2119>`.
+
 Overview
 --------
 


### PR DESCRIPTION
Fixes #381

Regarding the question of spelling "key word" or "keyword":

RFC 2119 explicitly recommnends how to reference to itself:
>Authors who follow these guidelines
>should incorporate this phrase near the beginning of their document:
>
>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
>"SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL"
>in this document are to be interpreted as described in RFC 2119.

In the Autocrypt document itself I chose here "keyword", which seems to be more common English. Since RFC 2119 states that the given phrase only "should" (not "SHOULD" BTW ;) be incorporated, I guess it's ok to change "key words" in the RFC phrase to "keywords" to have a consistent spelling in Autocrypt documentation and in the same time comply to RFC 2119.

I would suggest to leave any further linguistic discussion open for following pull requests.