### PR TITLE
Add key id in example

### DIFF
--- a/doc/appendix/example-simple-autocrypt.eml
+++ b/doc/appendix/example-simple-autocrypt.eml
@@ -39,5 +39,5 @@ Message-ID: <rsa-3072@autocrypt.example>
 MIME-Version: 1.0
 Content-Type: text/plain
 
-This is an example e-mail with Autocrypt header and RSA 3072 key
-as defined in Level 1.
+This is an example e-mail with Autocrypt header and RSA 3072 key (key
+id: 71DBC5657FDE65A7) as defined in Level 1.


### PR DESCRIPTION
Hi,
I added the example autocrypt header (https://autocrypt.org/level1.html#e-mail-address-canonicalization) to my test suite. I think the key id is 71DBC5657FDE65A7 and this was helpful for testing. May other can verify the key id and other find this helpful, too.

Best 
Oliver