### PR TITLE
Fix attribution links in the code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -71,8 +71,7 @@ temporary or permanent repercussions as determined by other maintainers.
 Attribution
 -----------
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the `Contributor Covenant`_, version 1.4,
+available at http://contributor-covenant.org/version/1/4
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+.. _Contributor Covenant: http://contributor-covenant.org


### PR DESCRIPTION
The links were previously in Markdown format, which did funny things to
https://autocrypt.org/code_of_conduct.html.