### PR TITLE
Using gossip_key should result in an ui-recommendation?

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -567,7 +567,7 @@ __________________________
 
 If ``public_key`` is ``null``, then set
 ``target-keys[to-addr]`` to ``gossip_key`` and set
-``preliminary-recommendation`` to ``discourage`` and skip to the
+``ui-recommendation`` to ``discourage`` and skip to the
 :ref:`final-recommendation-phase`.
 
 Otherwise, set ``target-keys[to-addr]`` to ``public_key``.


### PR DESCRIPTION
> If public_key is null, then set target-keys[to-addr] to gossip_key and set
    preliminary-recommendation to discourage and skip to the Deciding to Encrypt by Default
    (page 9).

If I understand it correctly, the use of gossip_key ends as a `preliminary-recommendation`, which is later never used, due to the fact that `Deciding to Encrypt by Default` is skipped.

So shouldn't the result of using the gossip_key be an ui-recommendation?