### PR TITLE
Ignore all automatically replied messages

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -412,9 +412,13 @@ header, by an MUA at receive or display time.
 Messages SHOULD be ignored (i.e., ``peers[from-addr]`` SHOULD NOT be
 updated) in the following cases:
 
+  - The message is explicitly marked as auto-replied with an
+    `Auto-Submitted: auto-replied` header (:rfc:`3834`).
+
   - The content-type is ``multipart/report``. In this case, it can be assumed
-    the message was auto-generated. This avoids triggering a ``reset``
-    state from received Message Disposition Notifications (:rfc:`3798`).
+    the message was auto-replied. This avoids triggering a ``reset``
+    state from received Message Disposition Notifications (:rfc:`3798`)
+    which may not have `Auto-Submitted: auto-replied` header.
 
   - There is more than one address in the ``From`` header.
 


### PR DESCRIPTION
multipart/report messages are not required to be placed at the root of
MIME message. RFC 8098 specifically allows it for Message Disposition
Notification. For example, reports may be combined into multipart/parallel
or multipart/mixed.

If these messages are properly marked as auto-replied, they can still
be ignored without parsing them recursively.