### PR TITLE
Update references to py-autocrypt to rebranded name muacrypt

### DIFF
--- a/doc/bot.rst
+++ b/doc/bot.rst
@@ -1,9 +1,9 @@
 Autocrypt bot
 +++++++++++++
 
-Implemented using `py-autocrypt`_.
+Implemented using `muacrypt`_.
 
-.. _py-autocrypt: https://py-autocrypt.readthedocs.io/
+.. _muacrypt: https://muacrypt.readthedocs.io/
 
 Responder
 ~~~~~~~~~~

--- a/doc/contact.rst
+++ b/doc/contact.rst
@@ -27,7 +27,7 @@ If you want to talk with us you may:
 See :doc:`dev-status` for links to ongoing development.
 Currently involved are developers from `K9/Android`_,
 `OpenKeyChain/Android`_, `Enigmail`_, `Delta.chat`_, `Mailpile`_, `Bitmask/LEAP`_,
-`py-autocrypt`_, `pyac`_ and `notmuch`_, as
+`muacrypt`_, `pyac`_ and `notmuch`_, as
 well as people from the `NEXTLEAP`_, `enzevalos`_ and panoramix_ research projects
 and the ACLU_.
 
@@ -37,7 +37,7 @@ and the ACLU_.
 .. _`Delta.Chat`: https://delta.chat/
 .. _`notmuch`: https://notmuchmail.org/
 .. _`Enigmail`: https://enigmail.net/
-.. _`py-autocrypt`: https://py-autocrypt.readthedocs.io/
+.. _`muacrypt`: https://muacrypt.readthedocs.io/
 .. _`pyac`: https://pyac.readthedocs.io/
 .. _`Mailpile`: https://mailpile.is/
 .. _`Bitmask/LEAP`: https://leap.se/en/docs/client


### PR DESCRIPTION
py-autocrypt has been rebranded to muacrypt (see https://github.com/hpk42/muacrypt/issues/34)