### PR TITLE
Fix broken link in doc/level1.rst

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -1217,7 +1217,8 @@ Earlier choices are better than later ones.
    specific software is installed, etc.) or if encrypted
    mails are found:
 
-   Inform the user about Autocrypt on <https://autocrypt.org/pgp-users>.
+   Inform the user about Autocrypt on
+   <https://autocrypt.org/other-crypto-interop.html#for-current-openpgp-users>.
 
 4. If no evidence for Autocrypt was found:
 


### PR DESCRIPTION
The link to <https://autocrypt.org/pgp-users> leads nowhere. I am
not sure if this page simply does not exist anymore or if it is not
implemented yet. In any case, the substituted link leads somewhere
at least.