### PR TITLE
Add Thunderbird native Autocrypt support to development status table 

### DIFF
--- a/doc/dev-status.rst
+++ b/doc/dev-status.rst
@@ -93,8 +93,6 @@ _ ``gossip``: sends out Autocrypt-Gossip headers
 .. _delta.chat: https://delta.chat/
 .. _thunderbird: https://www.thunderbird.net/
 .. _K-9 Mail: https://k9mail.github.io/
-.. _Autocrypt-Thunderbird: https://addons.thunderbird.net/en-US/thunderbird/addon/autocrypt/
-.. _Enigmail: https://www.enigmail.net/
 .. _Mutt: http://mutt.org/
 .. _Neomutt: https://neomutt.org/
 .. _`Letterbox`: https://letterbox-app.org/

--- a/doc/dev-status.rst
+++ b/doc/dev-status.rst
@@ -1,7 +1,7 @@
 Autocrypt-capable MUAs level 1 implementation status
 ====================================================
 
-Last updated: ``2024-06-10``
+Last updated: ``2024-06-17``
 
 Note that the below table is not complete and not up-to-date.
 Many more mail user agents support at least a subset of Autocrypt.
@@ -17,6 +17,10 @@ You are very welcome to submit a PR to update the below information, thanks!
 |.. image:: images/logos/deltachat.png |✔       |✔       |✔     |✔      |✔          |✔        |✔       |✔       |✔       |✔          |
 |                                      |        |        |      |       |           |         |        |        |        |           |
 |`delta.chat`_                         |        |        |      |       |           |         |        |        |        |           |
++--------------------------------------+--------+--------+------+-------+-----------+---------+--------+--------+--------+-----------+
+|.. image:: images/logos/tbird.png     |✔       |✔       |✘     |✔      |✔          |✔        |✘       |✘       |✔       |✘          |
+|                                      |        |        |      |       |           |         |        |        |        |           |
+|`thunderbird`_                        |        |        |      |       |           |         |        |        |        |           |
 +--------------------------------------+--------+--------+------+-------+-----------+---------+--------+--------+--------+-----------+
 |.. image:: images/logos/k9.png        |✔       |✔       |✔     |✔      |✔          |✔        |branch  |branch  |✔       |✔          |
 |                                      |        |        |      |       |           |         |        |        |        |           |
@@ -81,10 +85,13 @@ Legend:
 
 - ``setup process``: follows guidance with respect to Autocrypt account setup
 
+_ ``gossip``: sends out Autocrypt-Gossip headers
+
 - ``uid decorative``: UID in key data is only used for decorative
   purposes, and in particular not for looking up keys for an e-mail address.
 
 .. _delta.chat: https://delta.chat/
+.. _thunderbird: https://www.thunderbird.net/
 .. _K-9 Mail: https://k9mail.github.io/
 .. _Autocrypt-Thunderbird: https://addons.thunderbird.net/en-US/thunderbird/addon/autocrypt/
 .. _Enigmail: https://www.enigmail.net/


### PR DESCRIPTION
@kaie is this more or less correct?

I set `peer state` to unsupported because Thunderbird doesn't track the timestamp when a key was last seen, as far as I could tell from the UI. And pretty sure that it doesn't treat the user ID as decorative, e.g. the key of @hpk42 always gives me trouble because of this^^

The `gossip` column wasn't clearly defined, and Thunderbird only send `Autocrypt-Gossip` headers but doesn't seem to update peer state from received `Autocrypt-Gossip` headers. I first contemplated making this more clear in the column, but then again I don't know how it is for most of these implementations (though I'm pretty sure that if they have a checkmark for `gossip` they at least send out the header), so I was not comfortable with specifying that they all import keys from gossip headers. Maybe we should create another column for that at some point.